### PR TITLE
Add competitor editing functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Specific. Sourced. Tells me something I wouldn't have noticed. Has a clear so-wh
 | `src/lib/sources/youtube.test.ts` | 7 | Stats fetch, comment limits, dedup, HTML stripping, zero-comment skip, API errors |
 | `src/lib/analyze.test.ts` | 9 | JSON parsing, markdown-wrapped responses, empty/null/non-array responses, existing findings dedup, source formatting |
 | `src/app/api/run/route.test.ts` | 11 | Field validation, run creation, source filtering, default values, debug output |
+| `src/lib/findings-filter.test.ts` | 20 | Text search (claim, reality, why_it_matters, recommended_action), case-insensitivity, competitor/threat/confidence filters, combined filters, edge cases |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,32 @@ Specific. Sourced. Tells me something I wouldn't have noticed. Has a clear so-wh
 
 ---
 
+## Testing
+
+- **Framework**: Vitest with mocked `fetch` and external SDKs
+- **Run**: `npm test` (single run) or `npm run test:watch` (watch mode)
+- **Test location**: Co-located with source files (e.g. `analyze.ts` → `analyze.test.ts`)
+
+### Rules — always follow these
+
+- **Every new feature or bug fix must include tests.** If you add or modify logic in `src/lib/` or `src/app/api/`, add or update the corresponding `.test.ts` file in the same directory.
+- **Run `npm test` before committing.** All tests must pass. Do not commit with failing tests.
+- **Mock external dependencies, never call real APIs in tests.** Mock `fetch` for source modules (HN, Reddit, YouTube). Mock `@google/genai` for the analysis pipeline. Mock `@supabase/supabase-js` for the API route.
+- **Test the important behavior, not implementation details.** Focus on: input/output contracts, edge cases (null, empty, malformed data), deduplication logic, error handling paths, and data transformation (HTML stripping, markdown stripping, JSON parsing).
+- **Keep tests fast.** Mock rate-limit delays (`setTimeout`) in tests so the suite runs in under 2 seconds. No network calls, no database calls.
+
+### Current test coverage
+
+| File | Tests | What's covered |
+|------|-------|----------------|
+| `src/lib/sources/hackernews.test.ts` | 10 | Fuzzy variants, dedup, HTML stripping, sorting, null handling, API errors |
+| `src/lib/sources/reddit.test.ts` | 8 | Dedup, markdown stripping, AutoModerator filtering, engagement gating, cutoff, API errors |
+| `src/lib/sources/youtube.test.ts` | 7 | Stats fetch, comment limits, dedup, HTML stripping, zero-comment skip, API errors |
+| `src/lib/analyze.test.ts` | 9 | JSON parsing, markdown-wrapped responses, empty/null/non-array responses, existing findings dedup, source formatting |
+| `src/app/api/run/route.test.ts` | 11 | Field validation, run creation, source filtering, default values, debug output |
+
+---
+
 ## Roadmap
 
 - [ ] **Clerk authentication** — needed before public launch. RLS policies already written for JWT claims.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,283 @@
+# Recon Roadmap
+
+Organized by user problem, prioritized by impact. Each section maps to a GitHub issue.
+
+---
+
+## P0 — The product dies without these
+
+### 1. Scheduled runs (automated monitoring)
+**Problem**: Users must manually trigger every analysis. A competitive intelligence tool that requires you to remember to check it will be abandoned.
+
+**What to build**:
+- Vercel Cron job hitting `/api/run` on a schedule (default: Monday 7am)
+- Per-competitor scheduling: Primary = weekly, Secondary = biweekly, Watch = monthly
+- Settings page control for schedule frequency
+- Run history shows "scheduled" vs "manual" run type (schema already supports this)
+
+**Acceptance criteria**:
+- Competitors are analyzed on their configured schedule without user intervention
+- Runs page shows scheduled runs with correct type label
+
+**Labels**: `priority: P0`, `area: backend`
+
+---
+
+### 2. Email digests and alerts
+**Problem**: No one checks a dashboard daily. If a high-threat finding surfaces and sits unseen for a week, the tool failed. Email field exists in settings but is never used.
+
+**What to build**:
+- Weekly digest email: summary of new findings since last digest, grouped by threat level
+- Triggered alert: immediate email when a High-threat finding is created
+- Email provider: Resend (simple API, good DX)
+- Unsubscribe / frequency control in Settings
+
+**Acceptance criteria**:
+- User receives weekly email with new findings summary
+- High-threat findings trigger immediate email notification
+- Settings page controls email frequency and opt-out
+
+**Labels**: `priority: P0`, `area: backend`, `area: notifications`
+
+---
+
+### 3. Clerk authentication
+**Problem**: Single hardcoded user. Can't deploy publicly, can't support teams, RLS policies are disabled. Blocks every multi-user feature.
+
+**What to build**:
+- Clerk integration with Next.js middleware
+- Replace `TEMP_USER_ID` with Clerk JWT `sub` claim everywhere
+- Enable RLS policies in Supabase (already written in schema.sql)
+- Sign-in / sign-up pages
+
+**Acceptance criteria**:
+- Users can sign up, sign in, and only see their own data
+- RLS policies active in production
+- Existing temp-local-user data is migrated or reset
+
+**Labels**: `priority: P0`, `area: auth`, `area: backend`
+
+---
+
+## P1 — Makes the product actually useful day-to-day
+
+### 4. Clickable source links in findings
+**Problem**: Findings show "HN comment by user1" or "Reddit r/artificial post" but there's no link. Users can't verify the evidence or share it. Undermines trust.
+
+**What to build**:
+- Store source URLs alongside source descriptions in finding data
+- HN: link to `news.ycombinator.com/item?id=X`
+- Reddit: link to `reddit.com/r/sub/comments/X`
+- YouTube: link to `youtube.com/watch?v=X`
+- Finding detail page renders sources as clickable links
+
+**Acceptance criteria**:
+- Each source in a finding links to the original content
+- Existing findings without URLs gracefully fall back to text-only
+
+**Labels**: `priority: P1`, `area: data-quality`, `area: frontend`
+
+---
+
+### 5. Finding status workflow (triage)
+**Problem**: Findings pile up with no way to distinguish "already handled" from "needs attention." 50 findings and no triage = noise.
+
+**What to build**:
+- Finding status: `new` → `reviewed` → `acted_on` → `archived`
+- Bulk status update from findings list
+- Filter by status on findings page
+- Dashboard shows "X findings need review" (only `new` status)
+
+**Schema change**: Add `status` column to findings table (default: `new`)
+
+**Acceptance criteria**:
+- Users can triage findings through a status workflow
+- Dashboard surfaces untriaged count
+- Archived findings are hidden by default
+
+**Labels**: `priority: P1`, `area: frontend`, `area: backend`
+
+---
+
+### 6. Run error transparency
+**Problem**: When a source fails (rate limit, network error), the user sees "0 findings" and thinks the competitor has no signal. No way to tell "API failed" from "nothing found."
+
+**What to build**:
+- Return per-source status in API response: `{ source: "reddit", status: "error", error: "429 rate limited" }`
+- Show source health badges on run detail (green/yellow/red per source)
+- Surface "X sources failed" warning in run results
+- Show "findings filtered by 2-source minimum: Y candidates dropped" count
+
+**Acceptance criteria**:
+- Users can see which sources succeeded/failed per run
+- Partial failures don't silently produce misleading results
+
+**Labels**: `priority: P1`, `area: backend`, `area: frontend`
+
+---
+
+### 7. Competitor dossier page
+**Problem**: Findings are scattered in a flat list. No way to see "everything we know about Runway" in one view, or how their positioning has evolved.
+
+**What to build**:
+- `/competitors/[id]` page showing:
+  - Competitor details (name, priority, website, notes)
+  - Timeline of all findings, newest first
+  - Threat level trend (are findings getting more or less threatening?)
+  - Last run date and next scheduled run
+  - "Silence detection": flag if no findings in 2+ weeks despite active runs
+
+**Acceptance criteria**:
+- Clicking a competitor card navigates to a dossier view
+- Timeline shows positioning evolution over time
+- Silence is explicitly flagged
+
+**Labels**: `priority: P1`, `area: frontend`
+
+---
+
+### 8. Dashboard that drives action
+**Problem**: Dashboard shows stats but doesn't tell you what to do. "5 findings" is informational; "3 high-threat findings need review for Runway" is actionable.
+
+**What to build**:
+- "Needs attention" section: high-threat findings with status `new`
+- Per-competitor health: "Runway: 2 new findings, last run 3 days ago" vs "Pika: stale, last run 3 weeks ago"
+- Quick action: "Run stale competitors" button
+- "Last week" vs "last month" finding trend
+
+**Acceptance criteria**:
+- Dashboard surfaces actionable items, not just counts
+- Stale competitors are highlighted
+- One-click to run all stale competitors
+
+**Labels**: `priority: P1`, `area: frontend`
+
+---
+
+## P2 — Multiplayer and sharing
+
+### 9. Finding export (Slack, PDF, clipboard)
+**Problem**: PM discovers a critical competitive insight. Can't share it in Slack, can't paste it into a doc, can't attach it to a roadmap item. The insight dies in the tool.
+
+**What to build**:
+- "Copy to clipboard" button on finding detail (formatted markdown)
+- "Share to Slack" webhook integration (Settings page config)
+- Export findings list as CSV
+- Single finding export as formatted card (image or HTML)
+
+**Acceptance criteria**:
+- One-click copy produces a well-formatted summary
+- CSV export works from findings list with current filters applied
+
+**Labels**: `priority: P2`, `area: frontend`, `area: integrations`
+
+---
+
+### 10. Finding annotations and team notes
+**Problem**: Finding says "Runway claims cinematic quality." PM knows context: "We tested this last month, it's real for 4-second clips but falls apart at 10s." No way to capture that.
+
+**What to build**:
+- Notes/comments section on finding detail page
+- "We launched competing feature" annotation type
+- Internal team context that enriches the finding
+
+**Schema change**: New `finding_notes` table (finding_id, user_id, content, created_at)
+
+**Acceptance criteria**:
+- Users can add notes to findings
+- Notes persist and are visible to all team members (after auth)
+
+**Labels**: `priority: P2`, `area: frontend`, `area: backend`
+
+---
+
+## P3 — Scale and polish
+
+### 11. Date range filter on findings
+**Problem**: "Show me what happened in the last 2 weeks" is a natural query. Currently findings are sorted by date but can't be filtered by date range.
+
+**What to build**:
+- Date range picker in findings filter bar
+- Presets: "Last 7 days", "Last 30 days", "Last 90 days", "All time"
+
+**Labels**: `priority: P3`, `area: frontend`
+
+---
+
+### 12. Sort options for findings
+**Problem**: Findings are always sorted by creation date. Sometimes you want to see highest-threat first, or group by competitor.
+
+**What to build**:
+- Sort dropdown: "Newest", "Threat level", "Confidence", "Competitor"
+- Persist sort preference in localStorage
+
+**Labels**: `priority: P3`, `area: frontend`
+
+---
+
+### 13. Competitor search and priority filter
+**Problem**: With 20+ competitors, the competitors page becomes a long scroll. No way to filter by priority tier.
+
+**What to build**:
+- Search input on competitors page
+- Priority filter tabs: "All", "Primary", "Secondary", "Watch"
+
+**Labels**: `priority: P3`, `area: frontend`
+
+---
+
+### 14. Data freshness indicators per competitor
+**Problem**: User ran Competitor A yesterday and Competitor B 6 weeks ago. Dashboard shows "last run: yesterday" which is misleading. No per-competitor freshness.
+
+**What to build**:
+- "Last analyzed" date on each competitor card
+- Color coding: green (<7 days), yellow (7-21 days), red (>21 days)
+- Dashboard widget: "X competitors are stale"
+
+**Labels**: `priority: P3`, `area: frontend`
+
+---
+
+### 15. Twitter/X integration
+**Problem**: Highest volume competitive signal source, currently missing. Deferred due to $100/mo API cost.
+
+**What to build**:
+- Twitter API v2 integration (search recent tweets, user timelines)
+- Competitor Twitter handle config
+- Sentiment and engagement analysis
+
+**Blocker**: API cost — evaluate if the signal justifies $100/mo
+
+**Labels**: `priority: P3`, `area: sources`, `area: backend`
+
+---
+
+### 16. Finding quality feedback loop
+**Problem**: Some findings are spot-on, others miss the mark. No way to tell the system "this was useful" or "this was noise." Analysis quality stays static.
+
+**What to build**:
+- Thumbs up/down on findings
+- Track accuracy rate per competitor, per source
+- Feed quality signals back into analysis prompt (e.g., "users found Reddit-only findings less useful")
+
+**Labels**: `priority: P3`, `area: ml`, `area: frontend`
+
+---
+
+## Issue creation template
+
+For each item above, create a GitHub issue with:
+
+```
+Title: [P#] <title>
+Labels: <labels from above>
+Body:
+## Problem
+<problem description>
+
+## What to build
+<bullet list>
+
+## Acceptance criteria
+<bullet list>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,25 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jsdom": "^29.0.0",
         "tailwindcss": "^4",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -66,6 +77,67 @@
         "nun": "bin/nun.mjs",
         "nup": "bin/nup.mjs"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -534,6 +606,159 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.54.1",
       "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.54.1.tgz",
@@ -906,6 +1131,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2032,6 +2275,26 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2106,6 +2369,285 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2130,6 +2672,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.99.1",
@@ -2516,6 +3065,93 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -2601,6 +3237,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3249,6 +3911,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3562,6 +4337,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -3663,6 +4448,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -3860,6 +4655,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4156,6 +4961,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4189,6 +5015,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -4261,6 +5101,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -4377,6 +5224,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4408,6 +5266,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -4506,6 +5372,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -4641,6 +5520,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5162,6 +6048,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5226,6 +6122,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5566,6 +6472,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6050,6 +6971,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -6150,6 +7084,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -6560,6 +7504,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6843,6 +7794,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7380,6 +8382,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7398,6 +8411,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -7492,6 +8512,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7949,6 +8979,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8181,6 +9222,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8248,6 +9302,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8349,6 +9410,55 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -8549,6 +9659,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8713,6 +9837,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -8854,6 +10012,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -9218,6 +10389,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -9261,6 +10439,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -9269,6 +10454,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -9555,6 +10747,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9617,6 +10822,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -9670,6 +10882,13 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -9729,6 +10948,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "7.0.25",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
@@ -9769,15 +10998,28 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -10021,6 +11263,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -10174,6 +11426,467 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -10181,6 +11894,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -10285,6 +12033,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -10453,6 +12218,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
@@ -25,12 +27,16 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^29.0.0",
     "tailwindcss": "^4",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^4.1.0"
   }
 }

--- a/src/app/api/cron/run/route.test.ts
+++ b/src/app/api/cron/run/route.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getIntervalDays, isDue, GET } from "./route";
+import type { NextRequest } from "next/server";
+
+// Mock Supabase
+const mockFrom = vi.fn();
+const mockSupabase = { from: mockFrom };
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => mockSupabase),
+}));
+
+// Mock source fetchers
+vi.mock("@/lib/sources/hackernews", () => ({
+  fetchHackerNews: vi.fn().mockResolvedValue({
+    source: "hackernews",
+    queries: ["Test"],
+    stories: [],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/sources/reddit", () => ({
+  fetchReddit: vi.fn().mockResolvedValue({
+    source: "reddit",
+    queries: ["Test"],
+    subreddits: [],
+    posts: [],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/sources/youtube", () => ({
+  fetchYouTube: vi.fn().mockResolvedValue({
+    source: "youtube",
+    queries: ["Test"],
+    videos: [],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/analyze", () => ({
+  analyzeCompetitor: vi.fn().mockResolvedValue({
+    findings: [
+      {
+        claim: "Test claim",
+        reality: "Test reality",
+        confidence: "High",
+        threat_level: "Medium",
+        sources: ["HN", "Reddit"],
+        why_it_matters: "Important",
+        user_segment_overlap: "All",
+        compensating_advantages: "Ours",
+        recommended_action: "Watch",
+        testing_criteria: null,
+      },
+    ],
+    raw_response: "[]",
+  }),
+}));
+
+function makeRequest(headers?: Record<string, string>) {
+  return {
+    headers: {
+      get: (name: string) => headers?.[name] ?? null,
+    },
+  } as unknown as NextRequest;
+}
+
+// Helper to set up Supabase mock chain
+function setupMocks(opts: {
+  settings?: Record<string, unknown> | null;
+  settingsError?: boolean;
+  competitors?: Record<string, unknown>[];
+  latestRuns?: { competitor_id: string; completed_at: string }[];
+}) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "settings") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue(
+              opts.settingsError
+                ? { data: null, error: { code: "PGRST116", message: "Not found" } }
+                : { data: opts.settings ?? null, error: opts.settings ? null : { code: "PGRST116" } }
+            ),
+          }),
+        }),
+      };
+    }
+    if (table === "competitors") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({
+            data: opts.competitors ?? [],
+            error: null,
+          }),
+        }),
+      };
+    }
+    if (table === "runs") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({
+                data: opts.latestRuns ?? [],
+                error: null,
+              }),
+            }),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { id: "run-abc" },
+              error: null,
+            }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      };
+    }
+    if (table === "findings") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+    }
+    return {};
+  });
+}
+
+describe("getIntervalDays", () => {
+  it("returns priority-based default for 'default' frequency", () => {
+    expect(getIntervalDays("default", "Primary")).toBe(7);
+    expect(getIntervalDays("default", "Secondary")).toBe(14);
+    expect(getIntervalDays("default", "Watch")).toBe(30);
+  });
+
+  it("returns Infinity for 'never' frequency", () => {
+    expect(getIntervalDays("never", "Primary")).toBe(Infinity);
+  });
+
+  it("maps explicit frequencies to days", () => {
+    expect(getIntervalDays("daily", "Primary")).toBe(1);
+    expect(getIntervalDays("weekly", "Watch")).toBe(7);
+    expect(getIntervalDays("biweekly", "Watch")).toBe(14);
+    expect(getIntervalDays("monthly", "Primary")).toBe(30);
+  });
+
+  it("falls back to 30 for unknown priority with default", () => {
+    expect(getIntervalDays("default", "Unknown")).toBe(30);
+  });
+});
+
+describe("isDue", () => {
+  const now = new Date("2026-03-15T07:00:00Z");
+
+  it("returns true when never run", () => {
+    expect(isDue(null, 7, now)).toBe(true);
+  });
+
+  it("returns false for never frequency (Infinity interval)", () => {
+    expect(isDue(null, Infinity, now)).toBe(false);
+  });
+
+  it("returns true when interval has elapsed", () => {
+    // Last run 8 days ago, interval is 7 days
+    const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
+    expect(isDue(eightDaysAgo.toISOString(), 7, now)).toBe(true);
+  });
+
+  it("returns false when interval has not elapsed", () => {
+    // Last run 3 days ago, interval is 7 days
+    const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+    expect(isDue(threeDaysAgo.toISOString(), 7, now)).toBe(false);
+  });
+
+  it("returns true when exactly at interval boundary", () => {
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    expect(isDue(sevenDaysAgo.toISOString(), 7, now)).toBe(true);
+  });
+});
+
+describe("GET /api/cron/run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // No CRON_SECRET set by default
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 401 when CRON_SECRET is set and auth header is wrong", async () => {
+    process.env.CRON_SECRET = "my-secret";
+    setupMocks({ settings: null });
+
+    const req = makeRequest({ authorization: "Bearer wrong" });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("allows request when CRON_SECRET matches", async () => {
+    process.env.CRON_SECRET = "my-secret";
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews"],
+        product_name: "Test",
+        product_context: "Context",
+      },
+      competitors: [],
+    });
+
+    const req = makeRequest({ authorization: "Bearer my-secret" });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.skipped).toBe(true);
+    expect(json.reason).toContain("No competitors");
+  });
+
+  it("skips when no API key is configured", async () => {
+    setupMocks({ settings: { gemini_api_key: "", schedule_enabled: true } });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.skipped).toBe(true);
+    expect(json.reason).toContain("No Gemini API key");
+  });
+
+  it("skips when schedule is disabled", async () => {
+    setupMocks({
+      settings: { gemini_api_key: "key", schedule_enabled: false },
+    });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.skipped).toBe(true);
+    expect(json.reason).toContain("disabled");
+  });
+
+  it("skips when no competitors are configured", async () => {
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews"],
+        product_name: "P",
+        product_context: "C",
+      },
+      competitors: [],
+    });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.skipped).toBe(true);
+    expect(json.reason).toContain("No competitors");
+  });
+
+  it("reports no competitors due when all recently run", async () => {
+    const recentRun = new Date().toISOString();
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews"],
+        product_name: "P",
+        product_context: "C",
+      },
+      competitors: [
+        { id: "c1", name: "Rival", priority: "Primary", schedule_frequency: "default" },
+      ],
+      latestRuns: [{ competitor_id: "c1", completed_at: recentRun }],
+    });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.skipped).toBe(false);
+    expect(json.reason).toContain("No competitors due");
+    expect(json.checked).toBe(1);
+  });
+
+  it("runs analysis for due competitors", async () => {
+    const oldRun = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews", "reddit"],
+        product_name: "MyProduct",
+        product_context: "Context here",
+      },
+      competitors: [
+        { id: "c1", name: "Rival", priority: "Primary", schedule_frequency: "default" },
+      ],
+      latestRuns: [{ competitor_id: "c1", completed_at: oldRun }],
+    });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.ran).toBe(1);
+    expect(json.results[0].competitor).toBe("Rival");
+    expect(json.results[0].status).toBe("completed");
+    expect(json.results[0].findings_count).toBe(1);
+  });
+
+  it("runs never-before-run competitors", async () => {
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews"],
+        product_name: "P",
+        product_context: "C",
+      },
+      competitors: [
+        { id: "c2", name: "NewRival", priority: "Watch", schedule_frequency: "default" },
+      ],
+      latestRuns: [],
+    });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.ran).toBe(1);
+    expect(json.results[0].competitor).toBe("NewRival");
+    expect(json.results[0].status).toBe("completed");
+  });
+
+  it("skips competitors with 'never' schedule", async () => {
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews"],
+        product_name: "P",
+        product_context: "C",
+      },
+      competitors: [
+        { id: "c3", name: "ManualOnly", priority: "Primary", schedule_frequency: "never" },
+      ],
+      latestRuns: [],
+    });
+
+    const req = makeRequest();
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(json.skipped).toBe(false);
+    expect(json.reason).toContain("No competitors due");
+  });
+});

--- a/src/app/api/cron/run/route.test.ts
+++ b/src/app/api/cron/run/route.test.ts
@@ -142,6 +142,12 @@ function setupMocks(opts: {
   });
 }
 
+/** All route-level tests need CRON_SECRET set and Bearer header */
+function authedRequest() {
+  process.env.CRON_SECRET = "test-secret";
+  return makeRequest({ authorization: "Bearer test-secret" });
+}
+
 describe("getIntervalDays", () => {
   it("returns priority-based default for 'default' frequency", () => {
     expect(getIntervalDays("default", "Primary")).toBe(7);
@@ -177,13 +183,11 @@ describe("isDue", () => {
   });
 
   it("returns true when interval has elapsed", () => {
-    // Last run 8 days ago, interval is 7 days
     const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
     expect(isDue(eightDaysAgo.toISOString(), 7, now)).toBe(true);
   });
 
   it("returns false when interval has not elapsed", () => {
-    // Last run 3 days ago, interval is 7 days
     const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
     expect(isDue(threeDaysAgo.toISOString(), 7, now)).toBe(false);
   });
@@ -197,21 +201,33 @@ describe("isDue", () => {
 describe("GET /api/cron/run", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // No CRON_SECRET set by default
     delete process.env.CRON_SECRET;
   });
 
-  it("returns 401 when CRON_SECRET is set and auth header is wrong", async () => {
-    process.env.CRON_SECRET = "my-secret";
-    setupMocks({ settings: null });
+  // --- Auth tests ---
 
+  it("returns 401 when CRON_SECRET is not configured", async () => {
+    // No CRON_SECRET env var — endpoint should be locked down
+    const req = makeRequest({ authorization: "Bearer anything" });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when CRON_SECRET is set but auth header is wrong", async () => {
+    process.env.CRON_SECRET = "my-secret";
     const req = makeRequest({ authorization: "Bearer wrong" });
     const res = await GET(req);
     expect(res.status).toBe(401);
   });
 
-  it("allows request when CRON_SECRET matches", async () => {
+  it("returns 401 when no auth header is provided", async () => {
     process.env.CRON_SECRET = "my-secret";
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("allows request when CRON_SECRET matches", async () => {
     setupMocks({
       settings: {
         gemini_api_key: "key",
@@ -223,19 +239,18 @@ describe("GET /api/cron/run", () => {
       competitors: [],
     });
 
-    const req = makeRequest({ authorization: "Bearer my-secret" });
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.skipped).toBe(true);
-    expect(json.reason).toContain("No competitors");
   });
+
+  // --- Business logic tests (all authed) ---
 
   it("skips when no API key is configured", async () => {
     setupMocks({ settings: { gemini_api_key: "", schedule_enabled: true } });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
     expect(json.skipped).toBe(true);
     expect(json.reason).toContain("No Gemini API key");
@@ -246,8 +261,7 @@ describe("GET /api/cron/run", () => {
       settings: { gemini_api_key: "key", schedule_enabled: false },
     });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
     expect(json.skipped).toBe(true);
     expect(json.reason).toContain("disabled");
@@ -265,8 +279,7 @@ describe("GET /api/cron/run", () => {
       competitors: [],
     });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
     expect(json.skipped).toBe(true);
     expect(json.reason).toContain("No competitors");
@@ -288,8 +301,7 @@ describe("GET /api/cron/run", () => {
       latestRuns: [{ competitor_id: "c1", completed_at: recentRun }],
     });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
     expect(json.skipped).toBe(false);
     expect(json.reason).toContain("No competitors due");
@@ -312,14 +324,15 @@ describe("GET /api/cron/run", () => {
       latestRuns: [{ competitor_id: "c1", completed_at: oldRun }],
     });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
 
     expect(json.ran).toBe(1);
     expect(json.results[0].competitor).toBe("Rival");
     expect(json.results[0].status).toBe("completed");
     expect(json.results[0].findings_count).toBe(1);
+    // Should not leak internal error details
+    expect(json.results[0].error).toBeUndefined();
   });
 
   it("runs never-before-run competitors", async () => {
@@ -337,8 +350,7 @@ describe("GET /api/cron/run", () => {
       latestRuns: [],
     });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
 
     expect(json.ran).toBe(1);
@@ -361,11 +373,34 @@ describe("GET /api/cron/run", () => {
       latestRuns: [],
     });
 
-    const req = makeRequest();
-    const res = await GET(req);
+    const res = await GET(authedRequest());
     const json = await res.json();
 
     expect(json.skipped).toBe(false);
     expect(json.reason).toContain("No competitors due");
+  });
+
+  it("response does not contain internal error messages", async () => {
+    const oldRun = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    setupMocks({
+      settings: {
+        gemini_api_key: "key",
+        schedule_enabled: true,
+        enabled_sources: ["hackernews"],
+        product_name: "P",
+        product_context: "C",
+      },
+      competitors: [
+        { id: "c1", name: "Rival", priority: "Primary", schedule_frequency: "default" },
+      ],
+      latestRuns: [{ competitor_id: "c1", completed_at: oldRun }],
+    });
+
+    const res = await GET(authedRequest());
+    const json = await res.json();
+
+    // Ensure no error field leaks internal details
+    const responseStr = JSON.stringify(json);
+    expect(responseStr).not.toContain("error");
   });
 });

--- a/src/app/api/cron/run/route.ts
+++ b/src/app/api/cron/run/route.ts
@@ -1,0 +1,308 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { fetchHackerNews } from "@/lib/sources/hackernews";
+import { fetchReddit } from "@/lib/sources/reddit";
+import { fetchYouTube } from "@/lib/sources/youtube";
+import { analyzeCompetitor, type SourceData } from "@/lib/analyze";
+
+const TEMP_USER_ID = "temp-local-user";
+
+function getSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}
+
+/** Map priority to default interval in days */
+const PRIORITY_DEFAULTS: Record<string, number> = {
+  Primary: 7,
+  Secondary: 14,
+  Watch: 30,
+};
+
+/** Map explicit schedule_frequency to interval in days */
+const FREQUENCY_DAYS: Record<string, number> = {
+  daily: 1,
+  weekly: 7,
+  biweekly: 14,
+  monthly: 30,
+};
+
+/**
+ * Get the effective interval in days for a competitor.
+ * "default" uses priority-based interval, "never" returns Infinity.
+ */
+export function getIntervalDays(
+  scheduleFrequency: string,
+  priority: string
+): number {
+  if (scheduleFrequency === "never") return Infinity;
+  if (scheduleFrequency === "default") {
+    return PRIORITY_DEFAULTS[priority] ?? 30;
+  }
+  return FREQUENCY_DAYS[scheduleFrequency] ?? 30;
+}
+
+/**
+ * Determine which competitors are due for a scheduled run.
+ * A competitor is due if it has never been run, or if the time since
+ * its last completed run exceeds its schedule interval.
+ */
+export function isDue(
+  lastRunAt: string | null,
+  intervalDays: number,
+  now: Date
+): boolean {
+  if (intervalDays === Infinity) return false;
+  if (!lastRunAt) return true;
+  const elapsed = now.getTime() - new Date(lastRunAt).getTime();
+  const intervalMs = intervalDays * 24 * 60 * 60 * 1000;
+  return elapsed >= intervalMs;
+}
+
+export async function GET(req: NextRequest) {
+  // Verify cron secret to prevent unauthorized access
+  const authHeader = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getSupabase();
+  const now = new Date();
+
+  // 1. Load settings — bail if no API key configured
+  const { data: settings } = await supabase
+    .from("settings")
+    .select("*")
+    .eq("user_id", TEMP_USER_ID)
+    .single();
+
+  if (!settings?.gemini_api_key) {
+    return NextResponse.json({
+      skipped: true,
+      reason: "No Gemini API key configured in settings",
+    });
+  }
+
+  if (!settings.schedule_enabled) {
+    return NextResponse.json({
+      skipped: true,
+      reason: "Scheduled runs are disabled",
+    });
+  }
+
+  // 2. Load all competitors
+  const { data: competitors, error: compError } = await supabase
+    .from("competitors")
+    .select("*")
+    .eq("user_id", TEMP_USER_ID);
+
+  if (compError || !competitors?.length) {
+    return NextResponse.json({
+      skipped: true,
+      reason: compError ? compError.message : "No competitors configured",
+    });
+  }
+
+  // 3. For each competitor, find their most recent completed run
+  const { data: latestRuns } = await supabase
+    .from("runs")
+    .select("competitor_id, completed_at")
+    .eq("user_id", TEMP_USER_ID)
+    .eq("status", "completed")
+    .order("completed_at", { ascending: false });
+
+  // Build a map of competitor_id -> most recent completed_at
+  const lastRunMap = new Map<string, string>();
+  for (const run of latestRuns ?? []) {
+    if (!lastRunMap.has(run.competitor_id)) {
+      lastRunMap.set(run.competitor_id, run.completed_at!);
+    }
+  }
+
+  // 4. Filter to competitors that are due
+  const dueCompetitors = competitors.filter((c) => {
+    const intervalDays = getIntervalDays(
+      c.schedule_frequency ?? "default",
+      c.priority
+    );
+    return isDue(lastRunMap.get(c.id) ?? null, intervalDays, now);
+  });
+
+  if (dueCompetitors.length === 0) {
+    return NextResponse.json({
+      skipped: false,
+      reason: "No competitors due for analysis",
+      checked: competitors.length,
+    });
+  }
+
+  // 5. Run analysis for each due competitor sequentially
+  const activeSources: string[] = settings.enabled_sources ?? [
+    "hackernews",
+    "reddit",
+    "youtube",
+  ];
+  const results: {
+    competitor: string;
+    findings_count: number;
+    status: string;
+    error?: string;
+  }[] = [];
+
+  for (const competitor of dueCompetitors) {
+    let runId: string | null = null;
+
+    try {
+      // Create run record
+      const { data: run, error: runError } = await supabase
+        .from("runs")
+        .insert({
+          competitor_id: competitor.id,
+          type: "scheduled",
+          status: "running",
+          user_id: TEMP_USER_ID,
+        })
+        .select()
+        .single();
+
+      if (runError || !run) {
+        results.push({
+          competitor: competitor.name,
+          findings_count: 0,
+          status: "failed",
+          error: runError?.message ?? "Failed to create run",
+        });
+        continue;
+      }
+
+      runId = run.id as string;
+
+      // Fetch sources
+      const sourceData: SourceData = {};
+      let sourcesUsed = 0;
+
+      const fetches: Promise<{ key: string; result: unknown }>[] = [];
+
+      if (activeSources.includes("hackernews")) {
+        fetches.push(
+          fetchHackerNews(competitor.name, 90).then((r) => ({
+            key: "hn",
+            result: r,
+          }))
+        );
+      }
+      if (activeSources.includes("reddit")) {
+        fetches.push(
+          fetchReddit(competitor.name, 90).then((r) => ({
+            key: "reddit",
+            result: r,
+          }))
+        );
+      }
+      if (activeSources.includes("youtube")) {
+        fetches.push(
+          fetchYouTube(competitor.name, settings.gemini_api_key, 90).then(
+            (r) => ({ key: "youtube", result: r })
+          )
+        );
+      }
+
+      const fetchResults = await Promise.allSettled(fetches);
+
+      for (const r of fetchResults) {
+        if (r.status === "fulfilled") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (sourceData as any)[r.value.key] = r.value.result;
+          sourcesUsed++;
+        }
+      }
+
+      // Get existing claims to deduplicate
+      const { data: existingRows } = await supabase
+        .from("findings")
+        .select("claim")
+        .eq("competitor_id", competitor.id)
+        .order("created_at", { ascending: false })
+        .limit(20);
+
+      const existingClaims = (existingRows ?? []).map(
+        (r: { claim: string }) => r.claim
+      );
+
+      // Analyze
+      const analysis = await analyzeCompetitor(
+        competitor.name,
+        settings.product_name || "our product",
+        settings.product_context || "",
+        sourceData,
+        settings.gemini_api_key,
+        existingClaims
+      );
+
+      // Store findings
+      const findingsToInsert = analysis.findings.map((f) => ({
+        run_id: runId,
+        competitor_id: competitor.id,
+        claim: f.claim,
+        reality: f.reality,
+        confidence: f.confidence,
+        threat_level: f.threat_level,
+        sources: f.sources,
+        why_it_matters: f.why_it_matters || "",
+        user_segment_overlap: f.user_segment_overlap || "",
+        compensating_advantages: f.compensating_advantages || "",
+        recommended_action: f.recommended_action || "",
+        testing_criteria: f.testing_criteria,
+        user_id: TEMP_USER_ID,
+      }));
+
+      if (findingsToInsert.length > 0) {
+        await supabase.from("findings").insert(findingsToInsert);
+      }
+
+      // Mark run complete
+      await supabase
+        .from("runs")
+        .update({
+          status: "completed",
+          findings_count: analysis.findings.length,
+          sources_used: sourcesUsed,
+          completed_at: new Date().toISOString(),
+        })
+        .eq("id", runId);
+
+      results.push({
+        competitor: competitor.name,
+        findings_count: analysis.findings.length,
+        status: "completed",
+      });
+    } catch (error) {
+      if (runId) {
+        await supabase
+          .from("runs")
+          .update({
+            status: "failed",
+            completed_at: new Date().toISOString(),
+          })
+          .eq("id", runId);
+      }
+
+      results.push({
+        competitor: competitor.name,
+        findings_count: 0,
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return NextResponse.json({
+    ran: results.length,
+    total_competitors: competitors.length,
+    results,
+  });
+}

--- a/src/app/api/cron/run/route.ts
+++ b/src/app/api/cron/run/route.ts
@@ -7,6 +7,9 @@ import { analyzeCompetitor, type SourceData } from "@/lib/analyze";
 
 const TEMP_USER_ID = "temp-local-user";
 
+/** Maximum competitors to analyze per cron invocation to limit API spend */
+const MAX_COMPETITORS_PER_RUN = 10;
+
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -62,11 +65,11 @@ export function isDue(
 }
 
 export async function GET(req: NextRequest) {
-  // Verify cron secret to prevent unauthorized access
+  // Always require CRON_SECRET — if unset, the endpoint is locked down
   const authHeader = req.headers.get("authorization");
   const cronSecret = process.env.CRON_SECRET;
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -103,7 +106,7 @@ export async function GET(req: NextRequest) {
   if (compError || !competitors?.length) {
     return NextResponse.json({
       skipped: true,
-      reason: compError ? compError.message : "No competitors configured",
+      reason: "No competitors configured",
     });
   }
 
@@ -140,6 +143,9 @@ export async function GET(req: NextRequest) {
     });
   }
 
+  // Cap the number of competitors per invocation to limit API spend
+  const cappedCompetitors = dueCompetitors.slice(0, MAX_COMPETITORS_PER_RUN);
+
   // 5. Run analysis for each due competitor sequentially
   const activeSources: string[] = settings.enabled_sources ?? [
     "hackernews",
@@ -150,10 +156,9 @@ export async function GET(req: NextRequest) {
     competitor: string;
     findings_count: number;
     status: string;
-    error?: string;
   }[] = [];
 
-  for (const competitor of dueCompetitors) {
+  for (const competitor of cappedCompetitors) {
     let runId: string | null = null;
 
     try {
@@ -170,11 +175,11 @@ export async function GET(req: NextRequest) {
         .single();
 
       if (runError || !run) {
+        console.error(`Cron: failed to create run for ${competitor.id}:`, runError?.message);
         results.push({
           competitor: competitor.name,
           findings_count: 0,
           status: "failed",
-          error: runError?.message ?? "Failed to create run",
         });
         continue;
       }
@@ -291,18 +296,19 @@ export async function GET(req: NextRequest) {
           .eq("id", runId);
       }
 
+      console.error(`Cron: analysis failed for ${competitor.id}:`, error);
       results.push({
         competitor: competitor.name,
         findings_count: 0,
         status: "failed",
-        error: error instanceof Error ? error.message : String(error),
       });
     }
   }
 
   return NextResponse.json({
     ran: results.length,
-    total_competitors: competitors.length,
+    total_due: dueCompetitors.length,
+    capped: dueCompetitors.length > MAX_COMPETITORS_PER_RUN,
     results,
   });
 }

--- a/src/app/api/run/route.test.ts
+++ b/src/app/api/run/route.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+// Mock Supabase
+const mockFrom = vi.fn();
+const mockSupabase = { from: mockFrom };
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => mockSupabase),
+}));
+
+// Mock source fetchers
+vi.mock("@/lib/sources/hackernews", () => ({
+  fetchHackerNews: vi.fn().mockResolvedValue({
+    source: "hackernews",
+    queries: ["Test"],
+    stories: [],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/sources/reddit", () => ({
+  fetchReddit: vi.fn().mockResolvedValue({
+    source: "reddit",
+    queries: ["Test"],
+    subreddits: [],
+    posts: [],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/sources/youtube", () => ({
+  fetchYouTube: vi.fn().mockResolvedValue({
+    source: "youtube",
+    queries: ["Test"],
+    videos: [],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  }),
+}));
+
+// Mock analyzer
+vi.mock("@/lib/analyze", () => ({
+  analyzeCompetitor: vi.fn().mockResolvedValue({
+    findings: [
+      {
+        claim: "Test claim",
+        reality: "Test reality",
+        confidence: "High",
+        threat_level: "Medium",
+        sources: ["HN", "Reddit"],
+        why_it_matters: "Important",
+        user_segment_overlap: "All users",
+        compensating_advantages: "Our strength",
+        recommended_action: "Flag to team",
+        testing_criteria: null,
+      },
+    ],
+    raw_response: "[]",
+  }),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost:3000/api/run", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupSupabaseMocks(overrides?: {
+  runInsertError?: boolean;
+  findingsInsertError?: boolean;
+}) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "runs") {
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue(
+              overrides?.runInsertError
+                ? { data: null, error: { message: "Insert failed" } }
+                : { data: { id: "run-123" }, error: null }
+            ),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      };
+    }
+    if (table === "findings") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({
+                data: [],
+                error: null,
+              }),
+            }),
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({
+          error: overrides?.findingsInsertError
+            ? { message: "Insert failed" }
+            : null,
+        }),
+      };
+    }
+    return {};
+  });
+}
+
+describe("POST /api/run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupSupabaseMocks();
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const req = makeRequest({ competitor_id: "123" });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("Missing required fields");
+  });
+
+  it("returns 400 when competitor_name is missing", async () => {
+    const req = makeRequest({
+      competitor_id: "123",
+      gemini_api_key: "key",
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when gemini_api_key is missing", async () => {
+    const req = makeRequest({
+      competitor_id: "123",
+      competitor_name: "Test",
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when run creation fails", async () => {
+    setupSupabaseMocks({ runInsertError: true });
+
+    const req = makeRequest({
+      competitor_id: "123",
+      competitor_name: "TestCo",
+      gemini_api_key: "fake-key",
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain("Failed to create run");
+  });
+
+  it("returns successful response with findings", async () => {
+    const req = makeRequest({
+      competitor_id: "123",
+      competitor_name: "TestCo",
+      product_name: "OurProduct",
+      product_context: "We do stuff",
+      gemini_api_key: "fake-key",
+    });
+
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.run_id).toBe("run-123");
+    expect(json.findings_count).toBe(1);
+    expect(json.findings[0].claim).toBe("Test claim");
+    expect(json.debug).toBeDefined();
+  });
+
+  it("respects enabled_sources parameter", async () => {
+    const { fetchHackerNews } = await import("@/lib/sources/hackernews");
+    const { fetchReddit } = await import("@/lib/sources/reddit");
+    const { fetchYouTube } = await import("@/lib/sources/youtube");
+
+    const req = makeRequest({
+      competitor_id: "123",
+      competitor_name: "TestCo",
+      gemini_api_key: "fake-key",
+      enabled_sources: ["hackernews"],
+    });
+
+    await POST(req as unknown as import("next/server").NextRequest);
+
+    expect(fetchHackerNews).toHaveBeenCalled();
+    expect(fetchReddit).not.toHaveBeenCalled();
+    expect(fetchYouTube).not.toHaveBeenCalled();
+  });
+
+  it("defaults product_name to 'our product' when not provided", async () => {
+    const { analyzeCompetitor } = await import("@/lib/analyze");
+
+    const req = makeRequest({
+      competitor_id: "123",
+      competitor_name: "TestCo",
+      gemini_api_key: "fake-key",
+    });
+
+    await POST(req as unknown as import("next/server").NextRequest);
+
+    expect(analyzeCompetitor).toHaveBeenCalledWith(
+      "TestCo",
+      "our product",
+      "",
+      expect.any(Object),
+      "fake-key",
+      expect.any(Array)
+    );
+  });
+
+  it("includes debug info in response", async () => {
+    const req = makeRequest({
+      competitor_id: "123",
+      competitor_name: "TestCo",
+      gemini_api_key: "fake-key",
+    });
+
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    const json = await res.json();
+
+    expect(json.debug).toHaveProperty("hn_stories");
+    expect(json.debug).toHaveProperty("reddit_posts");
+    expect(json.debug).toHaveProperty("youtube_videos");
+    expect(json.debug).toHaveProperty("raw_response_preview");
+  });
+});

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -38,14 +38,16 @@ describe("GET /api/settings", () => {
     expect(res.status).toBe(200);
     expect(json.settings.product_name).toBe("");
     expect(json.settings.schedule_enabled).toBe(false);
+    expect(json.settings.has_api_key).toBe(false);
+    expect(json.settings.gemini_api_key).toBe("");
     expect(json.settings.enabled_sources).toEqual(["hackernews", "reddit", "youtube"]);
   });
 
-  it("returns saved settings when they exist", async () => {
+  it("returns saved settings with masked API key", async () => {
     const savedSettings = {
       product_name: "MyProduct",
       product_context: "We build stuff",
-      gemini_api_key: "AIza123",
+      gemini_api_key: "AIza1234567890abcdef",
       email: "me@co.com",
       enabled_sources: ["hackernews", "reddit"],
       schedule_enabled: true,
@@ -68,9 +70,32 @@ describe("GET /api/settings", () => {
     expect(res.status).toBe(200);
     expect(json.settings.product_name).toBe("MyProduct");
     expect(json.settings.schedule_enabled).toBe(true);
+    // API key should be masked
+    expect(json.settings.gemini_api_key).not.toBe("AIza1234567890abcdef");
+    expect(json.settings.gemini_api_key).toContain("****");
+    expect(json.settings.gemini_api_key).toMatch(/^AIza/);
+    expect(json.settings.gemini_api_key).toMatch(/cdef$/);
+    expect(json.settings.has_api_key).toBe(true);
   });
 
-  it("returns 500 on unexpected database error", async () => {
+  it("returns has_api_key false when key is empty", async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { gemini_api_key: "" },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const res = await GET();
+    const json = await res.json();
+    expect(json.settings.has_api_key).toBe(false);
+  });
+
+  it("returns 500 on unexpected database error without leaking details", async () => {
     mockFrom.mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
@@ -83,7 +108,11 @@ describe("GET /api/settings", () => {
     });
 
     const res = await GET();
+    const json = await res.json();
     expect(res.status).toBe(500);
+    // Should not leak internal error message
+    expect(json.error).toBe("Failed to load settings");
+    expect(json.details).toBeUndefined();
   });
 });
 
@@ -92,26 +121,38 @@ describe("PUT /api/settings", () => {
     vi.clearAllMocks();
   });
 
-  it("upserts settings and returns saved data", async () => {
+  it("upserts settings and returns masked API key", async () => {
     const upsertedData = {
       user_id: "temp-local-user",
       product_name: "NewProduct",
+      gemini_api_key: "AIzaNewKey12345678",
       schedule_enabled: true,
     };
 
-    mockFrom.mockReturnValue({
-      upsert: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: upsertedData,
-            error: null,
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "settings") {
+        return {
+          upsert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: upsertedData,
+                error: null,
+              }),
+            }),
           }),
-        }),
-      }),
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
     });
 
     const req = makePutRequest({
       product_name: "NewProduct",
+      gemini_api_key: "AIzaNewKey12345678",
       schedule_enabled: true,
     });
 
@@ -120,44 +161,158 @@ describe("PUT /api/settings", () => {
 
     expect(res.status).toBe(200);
     expect(json.settings.product_name).toBe("NewProduct");
+    // API key should be masked in response
+    expect(json.settings.gemini_api_key).not.toBe("AIzaNewKey12345678");
+    expect(json.settings.has_api_key).toBe(true);
   });
 
-  it("returns 500 on upsert failure", async () => {
-    mockFrom.mockReturnValue({
-      upsert: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: null,
-            error: { message: "Permission denied" },
+  it("returns 500 on upsert failure without leaking details", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "settings") {
+        return {
+          upsert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: { message: "Permission denied" },
+              }),
+            }),
           }),
-        }),
-      }),
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
     });
 
     const req = makePutRequest({ product_name: "Test" });
     const res = await PUT(req);
+    const json = await res.json();
     expect(res.status).toBe(500);
+    expect(json.error).toBe("Failed to save settings");
+    expect(json.details).toBeUndefined();
   });
 
-  it("defaults missing fields to empty/false", async () => {
+  it("rejects invalid email format", async () => {
+    const req = makePutRequest({ email: "not-an-email" });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("email");
+  });
+
+  it("rejects non-string product_name", async () => {
+    const req = makePutRequest({ product_name: 123 });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-boolean schedule_enabled", async () => {
+    const req = makePutRequest({ schedule_enabled: "yes" });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("filters invalid sources from enabled_sources", async () => {
     const upsertFn = vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
         single: vi.fn().mockResolvedValue({
-          data: { user_id: "temp-local-user" },
+          data: { user_id: "temp-local-user", gemini_api_key: "" },
           error: null,
         }),
       }),
     });
 
-    mockFrom.mockReturnValue({ upsert: upsertFn });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "settings") {
+        return {
+          upsert: upsertFn,
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
 
-    const req = makePutRequest({});
+    const req = makePutRequest({
+      enabled_sources: ["hackernews", "twitter", "malicious_source"],
+    });
     await PUT(req);
 
     const upsertCall = upsertFn.mock.calls[0][0];
-    expect(upsertCall.product_name).toBe("");
-    expect(upsertCall.gemini_api_key).toBe("");
-    expect(upsertCall.schedule_enabled).toBe(false);
-    expect(upsertCall.enabled_sources).toEqual(["hackernews", "reddit", "youtube"]);
+    expect(upsertCall.enabled_sources).toEqual(["hackernews"]);
+  });
+
+  it("preserves existing API key when not sent in request", async () => {
+    const upsertFn = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { user_id: "temp-local-user", gemini_api_key: "AIzaExisting123456" },
+          error: null,
+        }),
+      }),
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "settings") {
+        return {
+          upsert: upsertFn,
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { gemini_api_key: "AIzaExisting123456" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    // Don't include gemini_api_key in body
+    const req = makePutRequest({ product_name: "Test" });
+    await PUT(req);
+
+    const upsertCall = upsertFn.mock.calls[0][0];
+    expect(upsertCall.gemini_api_key).toBe("AIzaExisting123456");
+  });
+
+  it("truncates overly long product_name", async () => {
+    const upsertFn = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { user_id: "temp-local-user", gemini_api_key: "" },
+          error: null,
+        }),
+      }),
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "settings") {
+        return {
+          upsert: upsertFn,
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const longName = "A".repeat(500);
+    const req = makePutRequest({ product_name: longName });
+    await PUT(req);
+
+    const upsertCall = upsertFn.mock.calls[0][0];
+    expect(upsertCall.product_name.length).toBe(200);
   });
 });

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET, PUT } from "./route";
+import type { NextRequest } from "next/server";
+
+const mockFrom = vi.fn();
+const mockSupabase = { from: mockFrom };
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => mockSupabase),
+}));
+
+function makePutRequest(body: Record<string, unknown>) {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as NextRequest;
+}
+
+describe("GET /api/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns default settings when none exist", async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: null,
+            error: { code: "PGRST116", message: "No rows found" },
+          }),
+        }),
+      }),
+    });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.settings.product_name).toBe("");
+    expect(json.settings.schedule_enabled).toBe(false);
+    expect(json.settings.enabled_sources).toEqual(["hackernews", "reddit", "youtube"]);
+  });
+
+  it("returns saved settings when they exist", async () => {
+    const savedSettings = {
+      product_name: "MyProduct",
+      product_context: "We build stuff",
+      gemini_api_key: "AIza123",
+      email: "me@co.com",
+      enabled_sources: ["hackernews", "reddit"],
+      schedule_enabled: true,
+    };
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: savedSettings,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.settings.product_name).toBe("MyProduct");
+    expect(json.settings.schedule_enabled).toBe(true);
+  });
+
+  it("returns 500 on unexpected database error", async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: null,
+            error: { code: "42P01", message: "relation does not exist" },
+          }),
+        }),
+      }),
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("PUT /api/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upserts settings and returns saved data", async () => {
+    const upsertedData = {
+      user_id: "temp-local-user",
+      product_name: "NewProduct",
+      schedule_enabled: true,
+    };
+
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: upsertedData,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const req = makePutRequest({
+      product_name: "NewProduct",
+      schedule_enabled: true,
+    });
+
+    const res = await PUT(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.settings.product_name).toBe("NewProduct");
+  });
+
+  it("returns 500 on upsert failure", async () => {
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: null,
+            error: { message: "Permission denied" },
+          }),
+        }),
+      }),
+    });
+
+    const req = makePutRequest({ product_name: "Test" });
+    const res = await PUT(req);
+    expect(res.status).toBe(500);
+  });
+
+  it("defaults missing fields to empty/false", async () => {
+    const upsertFn = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { user_id: "temp-local-user" },
+          error: null,
+        }),
+      }),
+    });
+
+    mockFrom.mockReturnValue({ upsert: upsertFn });
+
+    const req = makePutRequest({});
+    await PUT(req);
+
+    const upsertCall = upsertFn.mock.calls[0][0];
+    expect(upsertCall.product_name).toBe("");
+    expect(upsertCall.gemini_api_key).toBe("");
+    expect(upsertCall.schedule_enabled).toBe(false);
+    expect(upsertCall.enabled_sources).toEqual(["hackernews", "reddit", "youtube"]);
+  });
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const TEMP_USER_ID = "temp-local-user";
+
+function getSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}
+
+export async function GET() {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from("settings")
+    .select("*")
+    .eq("user_id", TEMP_USER_ID)
+    .single();
+
+  if (error && error.code !== "PGRST116") {
+    return NextResponse.json(
+      { error: "Failed to load settings", details: error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    settings: data ?? {
+      product_name: "",
+      product_context: "",
+      gemini_api_key: "",
+      email: "",
+      enabled_sources: ["hackernews", "reddit", "youtube"],
+      schedule_enabled: false,
+    },
+  });
+}
+
+export async function PUT(req: NextRequest) {
+  const supabase = getSupabase();
+  const body = await req.json();
+
+  const {
+    product_name,
+    product_context,
+    gemini_api_key,
+    email,
+    enabled_sources,
+    schedule_enabled,
+  } = body;
+
+  // Upsert: insert if not exists, update if exists
+  const { data, error } = await supabase
+    .from("settings")
+    .upsert(
+      {
+        user_id: TEMP_USER_ID,
+        product_name: product_name ?? "",
+        product_context: product_context ?? "",
+        gemini_api_key: gemini_api_key ?? "",
+        email: email ?? "",
+        enabled_sources: enabled_sources ?? ["hackernews", "reddit", "youtube"],
+        schedule_enabled: schedule_enabled ?? false,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id" }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to save settings", details: error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ settings: data });
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -3,11 +3,23 @@ import { createClient } from "@supabase/supabase-js";
 
 const TEMP_USER_ID = "temp-local-user";
 
+const VALID_SOURCES = ["hackernews", "reddit", "youtube"];
+const MAX_PRODUCT_NAME_LENGTH = 200;
+const MAX_PRODUCT_CONTEXT_LENGTH = 2000;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_API_KEY_LENGTH = 256;
+
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
+}
+
+/** Mask an API key for safe display: show first 4 and last 4 chars */
+function maskApiKey(key: string): string {
+  if (!key || key.length < 10) return key ? "****" : "";
+  return `${key.slice(0, 4)}${"*".repeat(Math.min(key.length - 8, 20))}${key.slice(-4)}`;
 }
 
 export async function GET() {
@@ -21,26 +33,43 @@ export async function GET() {
 
   if (error && error.code !== "PGRST116") {
     return NextResponse.json(
-      { error: "Failed to load settings", details: error.message },
+      { error: "Failed to load settings" },
       { status: 500 }
     );
   }
 
-  return NextResponse.json({
-    settings: data ?? {
-      product_name: "",
-      product_context: "",
-      gemini_api_key: "",
-      email: "",
-      enabled_sources: ["hackernews", "reddit", "youtube"],
-      schedule_enabled: false,
-    },
-  });
+  // Never return the full API key to the client
+  const settings = data
+    ? {
+        ...data,
+        gemini_api_key: maskApiKey(data.gemini_api_key ?? ""),
+        has_api_key: !!(data.gemini_api_key && data.gemini_api_key.length > 0),
+      }
+    : {
+        product_name: "",
+        product_context: "",
+        gemini_api_key: "",
+        has_api_key: false,
+        email: "",
+        enabled_sources: ["hackernews", "reddit", "youtube"],
+        schedule_enabled: false,
+      };
+
+  return NextResponse.json({ settings });
 }
 
 export async function PUT(req: NextRequest) {
   const supabase = getSupabase();
-  const body = await req.json();
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
 
   const {
     product_name,
@@ -51,17 +80,68 @@ export async function PUT(req: NextRequest) {
     schedule_enabled,
   } = body;
 
-  // Upsert: insert if not exists, update if exists
+  // Validate field types and lengths
+  if (product_name !== undefined && typeof product_name !== "string") {
+    return NextResponse.json({ error: "product_name must be a string" }, { status: 400 });
+  }
+  if (product_context !== undefined && typeof product_context !== "string") {
+    return NextResponse.json({ error: "product_context must be a string" }, { status: 400 });
+  }
+  if (gemini_api_key !== undefined && typeof gemini_api_key !== "string") {
+    return NextResponse.json({ error: "gemini_api_key must be a string" }, { status: 400 });
+  }
+  if (email !== undefined && typeof email !== "string") {
+    return NextResponse.json({ error: "email must be a string" }, { status: 400 });
+  }
+  if (schedule_enabled !== undefined && typeof schedule_enabled !== "boolean") {
+    return NextResponse.json({ error: "schedule_enabled must be a boolean" }, { status: 400 });
+  }
+
+  const prodName = typeof product_name === "string" ? product_name.slice(0, MAX_PRODUCT_NAME_LENGTH) : "";
+  const prodContext = typeof product_context === "string" ? product_context.slice(0, MAX_PRODUCT_CONTEXT_LENGTH) : "";
+  const emailVal = typeof email === "string" ? email.slice(0, MAX_EMAIL_LENGTH) : "";
+
+  // Validate email format if provided
+  if (emailVal && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailVal)) {
+    return NextResponse.json({ error: "Invalid email address" }, { status: 400 });
+  }
+
+  // Allowlist enabled_sources
+  let validSources = VALID_SOURCES;
+  if (Array.isArray(enabled_sources)) {
+    validSources = enabled_sources.filter(
+      (s): s is string => typeof s === "string" && VALID_SOURCES.includes(s)
+    );
+    if (validSources.length === 0) {
+      validSources = VALID_SOURCES;
+    }
+  }
+
+  // Resolve API key: if not provided or masked, preserve existing key
+  let finalApiKey: string;
+  const rawApiKey = typeof gemini_api_key === "string" ? gemini_api_key.slice(0, MAX_API_KEY_LENGTH) : "";
+  if (!gemini_api_key || rawApiKey.includes("*")) {
+    // Key not sent or is the masked version — keep the stored key
+    const { data: existing } = await supabase
+      .from("settings")
+      .select("gemini_api_key")
+      .eq("user_id", TEMP_USER_ID)
+      .single();
+    finalApiKey = existing?.gemini_api_key ?? "";
+  } else {
+    finalApiKey = rawApiKey;
+  }
+
   const { data, error } = await supabase
     .from("settings")
     .upsert(
       {
         user_id: TEMP_USER_ID,
-        product_name: product_name ?? "",
-        product_context: product_context ?? "",
-        gemini_api_key: gemini_api_key ?? "",
-        email: email ?? "",
-        enabled_sources: enabled_sources ?? ["hackernews", "reddit", "youtube"],
+        product_name: prodName,
+        product_context: prodContext,
+        gemini_api_key: finalApiKey,
+        email: emailVal,
+        enabled_sources: validSources,
         schedule_enabled: schedule_enabled ?? false,
         updated_at: new Date().toISOString(),
       },
@@ -72,10 +152,17 @@ export async function PUT(req: NextRequest) {
 
   if (error) {
     return NextResponse.json(
-      { error: "Failed to save settings", details: error.message },
+      { error: "Failed to save settings" },
       { status: 500 }
     );
   }
 
-  return NextResponse.json({ settings: data });
+  // Return with masked key
+  return NextResponse.json({
+    settings: {
+      ...data,
+      gemini_api_key: maskApiKey(data.gemini_api_key ?? ""),
+      has_api_key: !!(data.gemini_api_key && data.gemini_api_key.length > 0),
+    },
+  });
 }

--- a/src/app/competitors/page.tsx
+++ b/src/app/competitors/page.tsx
@@ -60,6 +60,12 @@ export default function CompetitorsPage() {
   const [newDescription, setNewDescription] = useState("");
   const [newPriority, setNewPriority] = useState<CompetitorPriority>("Watch");
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editingCompetitor, setEditingCompetitor] = useState<Competitor | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editWebsite, setEditWebsite] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editPriority, setEditPriority] = useState<CompetitorPriority>("Watch");
 
   const supabase = createClient();
 
@@ -103,6 +109,39 @@ export default function CompetitorsPage() {
       setNewDescription("");
       setNewPriority("Watch");
       setOpen(false);
+    }
+    setSaving(false);
+  }
+
+  function openEdit(competitor: Competitor) {
+    setEditingCompetitor(competitor);
+    setEditName(competitor.name);
+    setEditWebsite(competitor.website ?? "");
+    setEditDescription(competitor.description ?? "");
+    setEditPriority((competitor.priority as CompetitorPriority) ?? "Watch");
+    setEditOpen(true);
+  }
+
+  async function handleEdit() {
+    if (!editingCompetitor || !editName.trim()) return;
+    setSaving(true);
+
+    const { error } = await supabase
+      .from("competitors")
+      .update({
+        name: editName,
+        website: editWebsite,
+        description: editDescription,
+        priority: editPriority,
+      })
+      .eq("id", editingCompetitor.id);
+
+    if (error) {
+      console.error("Failed to update competitor:", error);
+    } else {
+      await loadCompetitors();
+      setEditOpen(false);
+      setEditingCompetitor(null);
     }
     setSaving(false);
   }
@@ -244,7 +283,7 @@ export default function CompetitorsPage() {
                     }
                   />
                   <DropdownMenuContent align="end">
-                    <DropdownMenuItem disabled>
+                    <DropdownMenuItem onClick={() => openEdit(competitor)}>
                       <Pencil className="mr-2 h-4 w-4" />
                       Edit
                     </DropdownMenuItem>
@@ -297,6 +336,70 @@ export default function CompetitorsPage() {
           ))}
         </div>
       )}
+
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Competitor</DialogTitle>
+            <DialogDescription>
+              Update competitor details.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-name">Company Name</Label>
+              <Input
+                id="edit-name"
+                placeholder="e.g. Pika Labs"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-website">Website</Label>
+              <Input
+                id="edit-website"
+                placeholder="e.g. pika.art"
+                value={editWebsite}
+                onChange={(e) => setEditWebsite(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-priority">Priority</Label>
+              <Select value={editPriority} onValueChange={(v) => setEditPriority((v ?? "Watch") as CompetitorPriority)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Primary">Primary</SelectItem>
+                  <SelectItem value="Secondary">Secondary</SelectItem>
+                  <SelectItem value="Watch">Watch</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {editPriority === "Primary" && "Your top competitive threat. Gets the most source coverage and monitoring frequency."}
+                {editPriority === "Secondary" && "Worth tracking regularly, but not your most urgent threat."}
+                {editPriority === "Watch" && "On your radar. You'll be alerted if they make a significant move."}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-description">Notes</Label>
+              <Textarea
+                id="edit-description"
+                placeholder="Why are you tracking this competitor?"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+              />
+            </div>
+            <Button onClick={handleEdit} className="w-full" disabled={saving}>
+              {saving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Save Changes
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/competitors/page.tsx
+++ b/src/app/competitors/page.tsx
@@ -34,12 +34,28 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Plus, ExternalLink, MoreHorizontal, Loader2, Pencil, Trash2 } from "lucide-react";
+import { Plus, ExternalLink, MoreHorizontal, Loader2, Pencil, Trash2, CalendarClock } from "lucide-react";
 import { createClient } from "@/lib/supabase";
 import type { Database } from "@/lib/database.types";
 
 type Competitor = Database["public"]["Tables"]["competitors"]["Row"];
 type CompetitorPriority = "Primary" | "Secondary" | "Watch";
+type ScheduleFrequency = "default" | "daily" | "weekly" | "biweekly" | "monthly" | "never";
+
+const scheduleLabels: Record<ScheduleFrequency, string> = {
+  default: "Default (by priority)",
+  daily: "Daily",
+  weekly: "Weekly",
+  biweekly: "Every 2 weeks",
+  monthly: "Monthly",
+  never: "Never",
+};
+
+const priorityDefaultSchedule: Record<string, string> = {
+  Primary: "Weekly",
+  Secondary: "Every 2 weeks",
+  Watch: "Monthly",
+};
 
 const priorityVariant = {
   Primary: "destructive",
@@ -59,6 +75,7 @@ export default function CompetitorsPage() {
   const [newWebsite, setNewWebsite] = useState("");
   const [newDescription, setNewDescription] = useState("");
   const [newPriority, setNewPriority] = useState<CompetitorPriority>("Watch");
+  const [newSchedule, setNewSchedule] = useState<ScheduleFrequency>("default");
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [editOpen, setEditOpen] = useState(false);
   const [editingCompetitor, setEditingCompetitor] = useState<Competitor | null>(null);
@@ -66,6 +83,7 @@ export default function CompetitorsPage() {
   const [editWebsite, setEditWebsite] = useState("");
   const [editDescription, setEditDescription] = useState("");
   const [editPriority, setEditPriority] = useState<CompetitorPriority>("Watch");
+  const [editSchedule, setEditSchedule] = useState<ScheduleFrequency>("default");
 
   const supabase = createClient();
 
@@ -97,6 +115,7 @@ export default function CompetitorsPage() {
       website: newWebsite,
       description: newDescription,
       priority: newPriority,
+      schedule_frequency: newSchedule,
       user_id: TEMP_USER_ID,
     });
 
@@ -108,6 +127,7 @@ export default function CompetitorsPage() {
       setNewWebsite("");
       setNewDescription("");
       setNewPriority("Watch");
+      setNewSchedule("default");
       setOpen(false);
     }
     setSaving(false);
@@ -119,6 +139,7 @@ export default function CompetitorsPage() {
     setEditWebsite(competitor.website ?? "");
     setEditDescription(competitor.description ?? "");
     setEditPriority((competitor.priority as CompetitorPriority) ?? "Watch");
+    setEditSchedule((competitor.schedule_frequency as ScheduleFrequency) ?? "default");
     setEditOpen(true);
   }
 
@@ -133,6 +154,7 @@ export default function CompetitorsPage() {
         website: editWebsite,
         description: editDescription,
         priority: editPriority,
+        schedule_frequency: editSchedule,
       })
       .eq("id", editingCompetitor.id);
 
@@ -227,6 +249,25 @@ export default function CompetitorsPage() {
                   {newPriority === "Primary" && "Your top competitive threat. Gets the most source coverage and monitoring frequency."}
                   {newPriority === "Secondary" && "Worth tracking regularly, but not your most urgent threat."}
                   {newPriority === "Watch" && "On your radar. You'll be alerted if they make a significant move."}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="schedule">Schedule Frequency</Label>
+                <Select value={newSchedule} onValueChange={(v) => setNewSchedule((v ?? "default") as ScheduleFrequency)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default ({priorityDefaultSchedule[newPriority] ?? "Monthly"})</SelectItem>
+                    <SelectItem value="daily">Daily</SelectItem>
+                    <SelectItem value="weekly">Weekly</SelectItem>
+                    <SelectItem value="biweekly">Every 2 weeks</SelectItem>
+                    <SelectItem value="monthly">Monthly</SelectItem>
+                    <SelectItem value="never">Never (manual only)</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  How often this competitor is automatically analyzed when scheduled runs are enabled.
                 </p>
               </div>
               <div className="space-y-2">
@@ -326,6 +367,14 @@ export default function CompetitorsPage() {
                       <ExternalLink className="h-3 w-3" />
                     </a>
                   )}
+                  <span className="flex items-center gap-1">
+                    <CalendarClock className="h-3 w-3" />
+                    {competitor.schedule_frequency === "never"
+                      ? "Manual only"
+                      : competitor.schedule_frequency === "default"
+                        ? priorityDefaultSchedule[competitor.priority] ?? "Monthly"
+                        : scheduleLabels[competitor.schedule_frequency as ScheduleFrequency] ?? "Monthly"}
+                  </span>
                   <span>
                     Added{" "}
                     {new Date(competitor.created_at).toLocaleDateString()}
@@ -380,6 +429,25 @@ export default function CompetitorsPage() {
                 {editPriority === "Primary" && "Your top competitive threat. Gets the most source coverage and monitoring frequency."}
                 {editPriority === "Secondary" && "Worth tracking regularly, but not your most urgent threat."}
                 {editPriority === "Watch" && "On your radar. You'll be alerted if they make a significant move."}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-schedule">Schedule Frequency</Label>
+              <Select value={editSchedule} onValueChange={(v) => setEditSchedule((v ?? "default") as ScheduleFrequency)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">Default ({priorityDefaultSchedule[editPriority] ?? "Monthly"})</SelectItem>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                  <SelectItem value="biweekly">Every 2 weeks</SelectItem>
+                  <SelectItem value="monthly">Monthly</SelectItem>
+                  <SelectItem value="never">Never (manual only)</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                How often this competitor is automatically analyzed when scheduled runs are enabled.
               </p>
             </div>
             <div className="space-y-2">

--- a/src/app/findings/page.tsx
+++ b/src/app/findings/page.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import Link from "next/link";
+import { Input } from "@/components/ui/input";
 import {
   Filter,
   Loader2,
@@ -21,6 +22,7 @@ import {
   Trash2,
   CheckSquare,
   Square,
+  Search,
   X,
 } from "lucide-react";
 import { createClient } from "@/lib/supabase";
@@ -43,6 +45,7 @@ export default function FindingsPage() {
   const [findings, setFindings] = useState<Finding[]>([]);
   const [competitors, setCompetitors] = useState<Competitor[]>([]);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
   const [competitorFilter, setCompetitorFilter] = useState<string>("all");
   const [threatFilter, setThreatFilter] = useState<string>("all");
   const [confidenceFilter, setConfidenceFilter] = useState<string>("all");
@@ -81,6 +84,15 @@ export default function FindingsPage() {
     if (threatFilter !== "all" && f.threat_level !== threatFilter) return false;
     if (confidenceFilter !== "all" && f.confidence !== confidenceFilter)
       return false;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      const matchesSearch =
+        f.claim?.toLowerCase().includes(q) ||
+        f.reality?.toLowerCase().includes(q) ||
+        f.why_it_matters?.toLowerCase().includes(q) ||
+        f.recommended_action?.toLowerCase().includes(q);
+      if (!matchesSearch) return false;
+    }
     return true;
   });
 
@@ -272,7 +284,16 @@ export default function FindingsPage() {
         </div>
       )}
 
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search findings..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9 w-[220px]"
+          />
+        </div>
         <Filter className="h-4 w-4 text-muted-foreground" />
         <Select
           value={competitorFilter}
@@ -437,7 +458,7 @@ export default function FindingsPage() {
 
         {findings.length > 0 && filtered.length === 0 && (
           <div className="py-16 text-center text-muted-foreground">
-            No findings match the current filters.
+            No findings match {searchQuery ? `"${searchQuery}"` : "the current filters"}.
           </div>
         )}
       </div>

--- a/src/app/findings/page.tsx
+++ b/src/app/findings/page.tsx
@@ -26,6 +26,7 @@ import {
   X,
 } from "lucide-react";
 import { createClient } from "@/lib/supabase";
+import { filterFindings } from "@/lib/findings-filter";
 import type { Database } from "@/lib/database.types";
 
 type Finding = Database["public"]["Tables"]["findings"]["Row"];
@@ -79,21 +80,11 @@ export default function FindingsPage() {
     return competitors.find((c) => c.id === id)?.name ?? "Unknown";
   }
 
-  const filtered = findings.filter((f) => {
-    if (competitorFilter !== "all" && f.competitor_id !== competitorFilter) return false;
-    if (threatFilter !== "all" && f.threat_level !== threatFilter) return false;
-    if (confidenceFilter !== "all" && f.confidence !== confidenceFilter)
-      return false;
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      const matchesSearch =
-        f.claim?.toLowerCase().includes(q) ||
-        f.reality?.toLowerCase().includes(q) ||
-        f.why_it_matters?.toLowerCase().includes(q) ||
-        f.recommended_action?.toLowerCase().includes(q);
-      if (!matchesSearch) return false;
-    }
-    return true;
+  const filtered = filterFindings(findings, {
+    competitorId: competitorFilter,
+    threatLevel: threatFilter,
+    confidence: confidenceFilter,
+    search: searchQuery,
   });
 
   function toggleSelect(id: string) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -13,31 +13,89 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
-import { Check } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Check, Loader2, CalendarClock } from "lucide-react";
 
 export default function SettingsPage() {
   const [productName, setProductName] = useState("");
   const [productContext, setProductContext] = useState("");
   const [email, setEmail] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [scheduleEnabled, setScheduleEnabled] = useState(false);
   const [saved, setSaved] = useState<string | null>(null);
+  const [loadingSettings, setLoadingSettings] = useState(true);
+  const [savingAll, setSavingAll] = useState(false);
 
+  // Load settings from server on mount, fall back to localStorage
   useEffect(() => {
-    setProductName(
-      localStorage.getItem("recon_product_name") ?? "Google Vids"
-    );
-    setProductContext(
-      localStorage.getItem("recon_product_context") ??
-        "AI-powered video creation tool within Google Workspace. Core users: marketing teams, L&D, enterprise communications."
-    );
-    setEmail(localStorage.getItem("recon_email") ?? "");
-    setApiKey(localStorage.getItem("recon_gemini_key") ?? "");
+    async function load() {
+      try {
+        const res = await fetch("/api/settings");
+        if (res.ok) {
+          const { settings } = await res.json();
+          if (settings) {
+            setProductName(settings.product_name || localStorage.getItem("recon_product_name") || "Google Vids");
+            setProductContext(settings.product_context || localStorage.getItem("recon_product_context") || "AI-powered video creation tool within Google Workspace. Core users: marketing teams, L&D, enterprise communications.");
+            setEmail(settings.email || localStorage.getItem("recon_email") || "");
+            setApiKey(settings.gemini_api_key || localStorage.getItem("recon_gemini_key") || "");
+            setScheduleEnabled(settings.schedule_enabled ?? false);
+            setLoadingSettings(false);
+            return;
+          }
+        }
+      } catch {
+        // Fall back to localStorage
+      }
+      setProductName(localStorage.getItem("recon_product_name") ?? "Google Vids");
+      setProductContext(
+        localStorage.getItem("recon_product_context") ??
+          "AI-powered video creation tool within Google Workspace. Core users: marketing teams, L&D, enterprise communications."
+      );
+      setEmail(localStorage.getItem("recon_email") ?? "");
+      setApiKey(localStorage.getItem("recon_gemini_key") ?? "");
+      setLoadingSettings(false);
+    }
+    load();
   }, []);
 
-  function save(key: string, value: string, label: string) {
-    localStorage.setItem(key, value);
-    setSaved(label);
-    setTimeout(() => setSaved(null), 2000);
+  async function saveToServer(label: string) {
+    // Always keep localStorage in sync for the Runs page
+    localStorage.setItem("recon_product_name", productName);
+    localStorage.setItem("recon_product_context", productContext);
+    localStorage.setItem("recon_email", email);
+    localStorage.setItem("recon_gemini_key", apiKey);
+
+    setSavingAll(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          product_name: productName,
+          product_context: productContext,
+          gemini_api_key: apiKey,
+          email,
+          schedule_enabled: scheduleEnabled,
+        }),
+      });
+      if (res.ok) {
+        setSaved(label);
+        setTimeout(() => setSaved(null), 2000);
+      }
+    } catch {
+      // Still saved to localStorage
+      setSaved(label);
+      setTimeout(() => setSaved(null), 2000);
+    }
+    setSavingAll(false);
+  }
+
+  if (loadingSettings) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
   }
 
   return (
@@ -82,11 +140,12 @@ export default function SettingsPage() {
             </p>
           </div>
           <Button
-            onClick={() => {
-              save("recon_product_name", productName, "Product");
-              save("recon_product_context", productContext, "Product");
-            }}
+            onClick={() => saveToServer("Product")}
+            disabled={savingAll}
           >
+            {savingAll ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             {saved === "Product" ? (
               <span className="flex items-center gap-2">
                 <Check className="h-4 w-4" /> Saved
@@ -121,7 +180,13 @@ export default function SettingsPage() {
               Weekly digest and triggered alerts will be sent here.
             </p>
           </div>
-          <Button onClick={() => save("recon_email", email, "Email")}>
+          <Button
+            onClick={() => saveToServer("Email")}
+            disabled={savingAll}
+          >
+            {savingAll ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             {saved === "Email" ? (
               <span className="flex items-center gap-2">
                 <Check className="h-4 w-4" /> Saved
@@ -157,8 +222,12 @@ export default function SettingsPage() {
             </p>
           </div>
           <Button
-            onClick={() => save("recon_gemini_key", apiKey, "API Key")}
+            onClick={() => saveToServer("API Key")}
+            disabled={savingAll}
           >
+            {savingAll ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             {saved === "API Key" ? (
               <span className="flex items-center gap-2">
                 <Check className="h-4 w-4" /> Saved
@@ -167,6 +236,69 @@ export default function SettingsPage() {
               "Save API Key"
             )}
           </Button>
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <CardTitle className="text-base">Scheduled Runs</CardTitle>
+            <Badge variant={scheduleEnabled ? "default" : "secondary"}>
+              {scheduleEnabled ? "Active" : "Off"}
+            </Badge>
+          </div>
+          <CardDescription>
+            Automatically analyze competitors on a recurring schedule. Each
+            competitor runs based on its priority: Primary (weekly), Secondary
+            (biweekly), Watch (monthly) — or set a custom frequency per
+            competitor.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-start gap-4 rounded-lg border border-border p-4">
+            <CalendarClock className="mt-0.5 h-5 w-5 text-muted-foreground" />
+            <div className="flex-1 space-y-1">
+              <p className="text-sm font-medium">
+                {scheduleEnabled
+                  ? "Scheduled runs are enabled"
+                  : "Enable scheduled runs"}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {scheduleEnabled
+                  ? "Competitors will be analyzed automatically based on their schedule frequency. Requires a Gemini API key to be saved above."
+                  : "When enabled, a background job will check daily which competitors are due for analysis and run them automatically."}
+              </p>
+            </div>
+            <Button
+              variant={scheduleEnabled ? "outline" : "default"}
+              size="sm"
+              onClick={() => {
+                const next = !scheduleEnabled;
+                setScheduleEnabled(next);
+                // Save immediately when toggling
+                fetch("/api/settings", {
+                  method: "PUT",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    product_name: productName,
+                    product_context: productContext,
+                    gemini_api_key: apiKey,
+                    email,
+                    schedule_enabled: next,
+                  }),
+                }).catch(() => {});
+              }}
+            >
+              {scheduleEnabled ? "Disable" : "Enable"}
+            </Button>
+          </div>
+          {scheduleEnabled && !apiKey && (
+            <p className="text-xs text-destructive">
+              Save a Gemini API key above for scheduled runs to work.
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -21,6 +21,8 @@ export default function SettingsPage() {
   const [productContext, setProductContext] = useState("");
   const [email, setEmail] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [hasApiKey, setHasApiKey] = useState(false);
+  const [apiKeyDirty, setApiKeyDirty] = useState(false);
   const [scheduleEnabled, setScheduleEnabled] = useState(false);
   const [saved, setSaved] = useState<string | null>(null);
   const [loadingSettings, setLoadingSettings] = useState(true);
@@ -37,7 +39,10 @@ export default function SettingsPage() {
             setProductName(settings.product_name || localStorage.getItem("recon_product_name") || "Google Vids");
             setProductContext(settings.product_context || localStorage.getItem("recon_product_context") || "AI-powered video creation tool within Google Workspace. Core users: marketing teams, L&D, enterprise communications.");
             setEmail(settings.email || localStorage.getItem("recon_email") || "");
+            // API key comes back masked from server — show masked or localStorage fallback
             setApiKey(settings.gemini_api_key || localStorage.getItem("recon_gemini_key") || "");
+            setHasApiKey(settings.has_api_key ?? false);
+            setApiKeyDirty(false);
             setScheduleEnabled(settings.schedule_enabled ?? false);
             setLoadingSettings(false);
             return;
@@ -59,26 +64,37 @@ export default function SettingsPage() {
   }, []);
 
   async function saveToServer(label: string) {
-    // Always keep localStorage in sync for the Runs page
+    // Keep localStorage in sync for the Runs page
     localStorage.setItem("recon_product_name", productName);
     localStorage.setItem("recon_product_context", productContext);
     localStorage.setItem("recon_email", email);
-    localStorage.setItem("recon_gemini_key", apiKey);
+    // Only store real key in localStorage, not the masked version
+    if (apiKeyDirty) {
+      localStorage.setItem("recon_gemini_key", apiKey);
+    }
 
     setSavingAll(true);
     try {
+      // Only send the API key if the user typed a new one
+      const payload: Record<string, unknown> = {
+        product_name: productName,
+        product_context: productContext,
+        email,
+        schedule_enabled: scheduleEnabled,
+      };
+      if (apiKeyDirty) {
+        payload.gemini_api_key = apiKey;
+      }
+
       const res = await fetch("/api/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          product_name: productName,
-          product_context: productContext,
-          gemini_api_key: apiKey,
-          email,
-          schedule_enabled: scheduleEnabled,
-        }),
+        body: JSON.stringify(payload),
       });
       if (res.ok) {
+        const { settings } = await res.json();
+        setHasApiKey(settings?.has_api_key ?? hasApiKey);
+        setApiKeyDirty(false);
         setSaved(label);
         setTimeout(() => setSaved(null), 2000);
       }
@@ -215,7 +231,10 @@ export default function SettingsPage() {
               type="password"
               placeholder="AIza..."
               value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
+              onChange={(e) => {
+                setApiKey(e.target.value);
+                setApiKeyDirty(true);
+              }}
             />
             <p className="text-xs text-muted-foreground">
               Used for the analysis engine. Get one at aistudio.google.com.
@@ -277,14 +296,13 @@ export default function SettingsPage() {
               onClick={() => {
                 const next = !scheduleEnabled;
                 setScheduleEnabled(next);
-                // Save immediately when toggling
+                // Save immediately when toggling — don't send API key
                 fetch("/api/settings", {
                   method: "PUT",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({
                     product_name: productName,
                     product_context: productContext,
-                    gemini_api_key: apiKey,
                     email,
                     schedule_enabled: next,
                   }),
@@ -294,7 +312,7 @@ export default function SettingsPage() {
               {scheduleEnabled ? "Disable" : "Enable"}
             </Button>
           </div>
-          {scheduleEnabled && !apiKey && (
+          {scheduleEnabled && !hasApiKey && (
             <p className="text-xs text-destructive">
               Save a Gemini API key above for scheduled runs to work.
             </p>

--- a/src/lib/analyze.test.ts
+++ b/src/lib/analyze.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { analyzeCompetitor, type SourceData, type Finding } from "./analyze";
+
+// Shared mock for generateContent
+const mockGenerateContent = vi.fn();
+
+vi.mock("@google/genai", () => {
+  return {
+    GoogleGenAI: class {
+      models = {
+        generateContent: mockGenerateContent,
+      };
+    },
+  };
+});
+
+const sampleFindings: Finding[] = [
+  {
+    claim: "Competitor claims real-time collaboration",
+    reality: "Users report 3-5 second lag on HN and Reddit",
+    confidence: "High",
+    threat_level: "Medium",
+    sources: ["HN comment by user1", "Reddit r/artificial post"],
+    why_it_matters: "Our real-time editing is a key differentiator",
+    user_segment_overlap: "Teams using collaborative editing",
+    compensating_advantages: "Our latency is under 100ms",
+    recommended_action: "Flag to team",
+    testing_criteria: null,
+  },
+];
+
+const sampleSourceData: SourceData = {
+  hn: {
+    source: "hackernews",
+    queries: ["Competitor"],
+    stories: [
+      {
+        id: "1",
+        title: "Competitor launches new feature",
+        url: "https://example.com",
+        author: "hn_user",
+        points: 150,
+        numComments: 30,
+        createdAt: "2025-06-01T00:00:00Z",
+      },
+    ],
+    comments: [
+      {
+        id: "c1",
+        text: "Their collaboration feature is laggy",
+        author: "dev_user",
+        storyTitle: "Competitor launches new feature",
+        createdAt: "2025-06-01T01:00:00Z",
+      },
+    ],
+    fetchedAt: new Date().toISOString(),
+  },
+  reddit: {
+    source: "reddit",
+    queries: ["Competitor"],
+    subreddits: ["artificial"],
+    posts: [
+      {
+        id: "r1",
+        title: "Competitor review",
+        selftext: "Real-time collab has noticeable delay",
+        author: "redditor",
+        score: 45,
+        numComments: 12,
+        subreddit: "artificial",
+        url: "https://reddit.com/r/artificial/test",
+        createdAt: "2025-06-02T00:00:00Z",
+      },
+    ],
+    comments: [],
+    fetchedAt: new Date().toISOString(),
+  },
+};
+
+describe("analyzeCompetitor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns findings from a valid JSON array response", async () => {
+    mockGenerateContent.mockResolvedValue({
+      text: JSON.stringify(sampleFindings),
+    });
+
+    const result = await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "We build collaborative tools",
+      sampleSourceData,
+      "fake-api-key"
+    );
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].claim).toBe("Competitor claims real-time collaboration");
+    expect(result.raw_response).toBeDefined();
+  });
+
+  it("extracts JSON array from markdown-wrapped response", async () => {
+    const wrappedResponse = `Here are the findings:\n\`\`\`json\n${JSON.stringify(sampleFindings)}\n\`\`\``;
+    mockGenerateContent.mockResolvedValue({ text: wrappedResponse });
+
+    const result = await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      sampleSourceData,
+      "fake-api-key"
+    );
+
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("returns empty findings for completely unparseable response", async () => {
+    mockGenerateContent.mockResolvedValue({ text: "I cannot analyze this data properly." });
+
+    const result = await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      sampleSourceData,
+      "fake-api-key"
+    );
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("returns empty findings when response is empty string", async () => {
+    mockGenerateContent.mockResolvedValue({ text: "" });
+
+    const result = await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      sampleSourceData,
+      "fake-api-key"
+    );
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("handles null text in response", async () => {
+    mockGenerateContent.mockResolvedValue({ text: null });
+
+    const result = await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      sampleSourceData,
+      "fake-api-key"
+    );
+
+    expect(result.findings).toEqual([]);
+    expect(result.raw_response).toBe("");
+  });
+
+  it("passes existing findings to avoid duplicates", async () => {
+    mockGenerateContent.mockResolvedValue({ text: "[]" });
+
+    await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      sampleSourceData,
+      "fake-api-key",
+      ["Existing claim A", "Existing claim B"]
+    );
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.contents).toContain("Existing claim A");
+    expect(callArgs.contents).toContain("Existing claim B");
+  });
+
+  it("includes all provided sources in the prompt", async () => {
+    mockGenerateContent.mockResolvedValue({ text: "[]" });
+
+    const fullSourceData: SourceData = {
+      ...sampleSourceData,
+      youtube: {
+        source: "youtube",
+        queries: ["Competitor"],
+        videos: [
+          {
+            id: "yt1",
+            title: "Competitor Review",
+            channelTitle: "TechReview",
+            publishedAt: "2025-06-01T00:00:00Z",
+            viewCount: "50000",
+            commentCount: "100",
+          },
+        ],
+        comments: [],
+        fetchedAt: new Date().toISOString(),
+      },
+    };
+
+    await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      fullSourceData,
+      "fake-api-key"
+    );
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.contents).toContain("Hacker News");
+    expect(callArgs.contents).toContain("Reddit");
+    expect(callArgs.contents).toContain("YouTube");
+  });
+
+  it("handles source data with only one source", async () => {
+    mockGenerateContent.mockResolvedValue({ text: "[]" });
+
+    await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      { hn: sampleSourceData.hn },
+      "fake-api-key"
+    );
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.contents).toContain("Hacker News");
+    // "Reddit" appears in rules text, so check that no Reddit section header is present
+    expect(callArgs.contents).not.toContain("## Reddit");
+  });
+
+  it("handles non-array JSON response", async () => {
+    mockGenerateContent.mockResolvedValue({
+      text: JSON.stringify({ error: "not an array" }),
+    });
+
+    const result = await analyzeCompetitor(
+      "Competitor",
+      "OurProduct",
+      "context",
+      sampleSourceData,
+      "fake-api-key"
+    );
+
+    expect(result.findings).toEqual([]);
+  });
+});

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -16,6 +16,7 @@ export type Database = {
           website: string;
           description: string;
           priority: string;
+          schedule_frequency: string;
           user_id: string;
           created_at: string;
           updated_at: string;
@@ -26,6 +27,7 @@ export type Database = {
           website?: string;
           description?: string;
           priority?: string;
+          schedule_frequency?: string;
           user_id: string;
           created_at?: string;
           updated_at?: string;
@@ -36,6 +38,7 @@ export type Database = {
           website?: string;
           description?: string;
           priority?: string;
+          schedule_frequency?: string;
           user_id?: string;
           updated_at?: string;
         };
@@ -182,6 +185,42 @@ export type Database = {
             referencedColumns: ["id"];
           },
         ];
+      };
+      settings: {
+        Row: {
+          id: string;
+          user_id: string;
+          product_name: string;
+          product_context: string;
+          gemini_api_key: string;
+          email: string;
+          enabled_sources: string[];
+          schedule_enabled: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          product_name?: string;
+          product_context?: string;
+          gemini_api_key?: string;
+          email?: string;
+          enabled_sources?: string[];
+          schedule_enabled?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          product_name?: string;
+          product_context?: string;
+          gemini_api_key?: string;
+          email?: string;
+          enabled_sources?: string[];
+          schedule_enabled?: boolean;
+          updated_at?: string;
+        };
+        Relationships: [];
       };
     };
     Views: Record<string, never>;

--- a/src/lib/findings-filter.test.ts
+++ b/src/lib/findings-filter.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import { filterFindings, type FindingFilters } from "./findings-filter";
+import type { Database } from "./database.types";
+
+type Finding = Database["public"]["Tables"]["findings"]["Row"];
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "f1",
+    run_id: "run1",
+    competitor_id: "comp1",
+    claim: "Competitor claims fast rendering",
+    reality: "Users report slow performance on large files",
+    confidence: "High",
+    threat_level: "Medium",
+    sources: ["HN", "Reddit"],
+    why_it_matters: "Affects our video editing workflow",
+    user_segment_overlap: "Professional editors",
+    compensating_advantages: "Our batch processing is faster",
+    recommended_action: "Flag to team",
+    testing_criteria: null,
+    user_id: "temp-local-user",
+    created_at: "2025-06-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const findings: Finding[] = [
+  makeFinding({
+    id: "f1",
+    competitor_id: "comp1",
+    claim: "Competitor claims fast rendering",
+    reality: "Users report slow performance",
+    threat_level: "High",
+    confidence: "High",
+    why_it_matters: "Affects video editing",
+    recommended_action: "Manual test recommended",
+  }),
+  makeFinding({
+    id: "f2",
+    competitor_id: "comp2",
+    claim: "New AI feature announced",
+    reality: "Feature is beta only, crashes frequently",
+    threat_level: "Medium",
+    confidence: "Medium",
+    why_it_matters: "Could attract our enterprise users",
+    recommended_action: "Flag to team",
+  }),
+  makeFinding({
+    id: "f3",
+    competitor_id: "comp1",
+    claim: "Pricing reduced by 50%",
+    reality: "Only for annual plans, monthly unchanged",
+    threat_level: "Low",
+    confidence: "High",
+    why_it_matters: "Pricing pressure on our free tier",
+    recommended_action: "No action needed",
+  }),
+  makeFinding({
+    id: "f4",
+    competitor_id: "comp3",
+    claim: "Partnership with Adobe",
+    reality: "Just an integration, not deep partnership",
+    threat_level: "Monitor",
+    confidence: "Low",
+    why_it_matters: "Distribution channel expansion",
+    recommended_action: "Escalate",
+  }),
+];
+
+describe("filterFindings", () => {
+  // --- No filters ---
+  it("returns all findings when no filters applied", () => {
+    const result = filterFindings(findings, {});
+    expect(result).toHaveLength(4);
+  });
+
+  it("returns all findings when all filters set to 'all'", () => {
+    const result = filterFindings(findings, {
+      competitorId: "all",
+      threatLevel: "all",
+      confidence: "all",
+    });
+    expect(result).toHaveLength(4);
+  });
+
+  // --- Competitor filter ---
+  it("filters by competitor ID", () => {
+    const result = filterFindings(findings, { competitorId: "comp1" });
+    expect(result).toHaveLength(2);
+    expect(result.every((f) => f.competitor_id === "comp1")).toBe(true);
+  });
+
+  it("returns empty for non-existent competitor", () => {
+    const result = filterFindings(findings, { competitorId: "nonexistent" });
+    expect(result).toHaveLength(0);
+  });
+
+  // --- Threat level filter ---
+  it("filters by threat level", () => {
+    const result = filterFindings(findings, { threatLevel: "High" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f1");
+  });
+
+  it("filters by Monitor threat level", () => {
+    const result = filterFindings(findings, { threatLevel: "Monitor" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f4");
+  });
+
+  // --- Confidence filter ---
+  it("filters by confidence", () => {
+    const result = filterFindings(findings, { confidence: "Medium" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f2");
+  });
+
+  // --- Text search ---
+  it("searches across claim field", () => {
+    const result = filterFindings(findings, { search: "rendering" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f1");
+  });
+
+  it("searches across reality field", () => {
+    const result = filterFindings(findings, { search: "crashes" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f2");
+  });
+
+  it("searches across why_it_matters field", () => {
+    const result = filterFindings(findings, { search: "enterprise" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f2");
+  });
+
+  it("searches across recommended_action field", () => {
+    const result = filterFindings(findings, { search: "escalate" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f4");
+  });
+
+  it("search is case-insensitive", () => {
+    const result = filterFindings(findings, { search: "PRICING" });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f3");
+  });
+
+  it("search returns multiple matches", () => {
+    const result = filterFindings(findings, { search: "competitor" });
+    // "Competitor claims fast rendering" and potentially others
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("search returns empty for no match", () => {
+    const result = filterFindings(findings, { search: "xyznonexistent" });
+    expect(result).toHaveLength(0);
+  });
+
+  it("empty search string returns all findings", () => {
+    const result = filterFindings(findings, { search: "" });
+    expect(result).toHaveLength(4);
+  });
+
+  // --- Combined filters ---
+  it("combines competitor filter with search", () => {
+    const result = filterFindings(findings, {
+      competitorId: "comp1",
+      search: "pricing",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f3");
+  });
+
+  it("combines threat level with confidence filter", () => {
+    const result = filterFindings(findings, {
+      threatLevel: "High",
+      confidence: "High",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f1");
+  });
+
+  it("combines all filters with search", () => {
+    const result = filterFindings(findings, {
+      competitorId: "comp1",
+      threatLevel: "High",
+      confidence: "High",
+      search: "rendering",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("f1");
+  });
+
+  it("combined filters can produce empty results", () => {
+    const result = filterFindings(findings, {
+      competitorId: "comp1",
+      threatLevel: "Monitor", // comp1 has no Monitor findings
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  // --- Edge cases ---
+  it("handles empty findings array", () => {
+    const result = filterFindings([], { search: "anything" });
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/lib/findings-filter.ts
+++ b/src/lib/findings-filter.ts
@@ -1,0 +1,38 @@
+import type { Database } from "@/lib/database.types";
+
+type Finding = Database["public"]["Tables"]["findings"]["Row"];
+
+export interface FindingFilters {
+  competitorId?: string;
+  threatLevel?: string;
+  confidence?: string;
+  search?: string;
+}
+
+/**
+ * Filters findings by competitor, threat level, confidence, and free-text search.
+ * Search matches against claim, reality, why_it_matters, and recommended_action.
+ */
+export function filterFindings(
+  findings: Finding[],
+  filters: FindingFilters
+): Finding[] {
+  return findings.filter((f) => {
+    if (filters.competitorId && filters.competitorId !== "all" && f.competitor_id !== filters.competitorId)
+      return false;
+    if (filters.threatLevel && filters.threatLevel !== "all" && f.threat_level !== filters.threatLevel)
+      return false;
+    if (filters.confidence && filters.confidence !== "all" && f.confidence !== filters.confidence)
+      return false;
+    if (filters.search) {
+      const q = filters.search.toLowerCase();
+      const matchesSearch =
+        f.claim?.toLowerCase().includes(q) ||
+        f.reality?.toLowerCase().includes(q) ||
+        f.why_it_matters?.toLowerCase().includes(q) ||
+        f.recommended_action?.toLowerCase().includes(q);
+      if (!matchesSearch) return false;
+    }
+    return true;
+  });
+}

--- a/src/lib/sources/hackernews.test.ts
+++ b/src/lib/sources/hackernews.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchHackerNews } from "./hackernews";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function mockHNResponse(stories: unknown[] = [], comments: unknown[] = []) {
+  mockFetch.mockImplementation((url: string) => {
+    const isComment = url.includes("tags=comment");
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          hits: isComment ? comments : stories,
+        }),
+    });
+  });
+}
+
+describe("fetchHackerNews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns correct structure with empty results", async () => {
+    mockHNResponse();
+    const result = await fetchHackerNews("TestCompany");
+
+    expect(result.source).toBe("hackernews");
+    expect(result.queries).toContain("TestCompany");
+    expect(result.stories).toEqual([]);
+    expect(result.comments).toEqual([]);
+    expect(result.fetchedAt).toBeDefined();
+  });
+
+  it("generates fuzzy search variants for camelCase names", async () => {
+    mockHNResponse();
+    const result = await fetchHackerNews("RunwayML");
+
+    expect(result.queries).toContain("RunwayML");
+    expect(result.queries).toContain("Runway ML");
+    expect(result.queries).toContain("runwayml");
+  });
+
+  it("generates variants for multi-word names", async () => {
+    mockHNResponse();
+    const result = await fetchHackerNews("Pika Labs");
+
+    expect(result.queries).toContain("Pika Labs");
+    expect(result.queries).toContain("PikaLabs");
+    expect(result.queries).toContain("Pika");
+    expect(result.queries).toContain("pika labs");
+  });
+
+  it("does not extract first word if it is shorter than 4 chars", async () => {
+    mockHNResponse();
+    const result = await fetchHackerNews("AI Corp");
+
+    // "AI" is only 2 chars, should not be extracted as a standalone variant
+    expect(result.queries).not.toContain("AI");
+  });
+
+  it("deduplicates stories by objectID", async () => {
+    const story = {
+      objectID: "123",
+      title: "Test Story",
+      url: "https://example.com",
+      author: "user1",
+      points: 100,
+      num_comments: 5,
+      created_at: "2025-01-01T00:00:00Z",
+    };
+    // Same story returned for multiple query variants
+    mockHNResponse([story, story]);
+
+    const result = await fetchHackerNews("TestCompany");
+    const ids = result.stories.map((s) => s.id);
+    const uniqueIds = new Set(ids);
+    expect(ids.length).toBe(uniqueIds.size);
+  });
+
+  it("deduplicates comments by objectID", async () => {
+    const comment = {
+      objectID: "456",
+      comment_text: "Great product",
+      author: "user2",
+      story_title: "Some Story",
+      created_at: "2025-01-01T00:00:00Z",
+    };
+    mockHNResponse([], [comment, comment]);
+
+    const result = await fetchHackerNews("TestCompany");
+    const ids = result.comments.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("strips HTML from comment text", async () => {
+    const comment = {
+      objectID: "789",
+      comment_text: "<p>This is <b>bold</b> &amp; &lt;cool&gt;</p>",
+      author: "user3",
+      story_title: "Test",
+      created_at: "2025-01-01T00:00:00Z",
+    };
+    mockHNResponse([], [comment]);
+
+    const result = await fetchHackerNews("TestCompany");
+    expect(result.comments[0].text).toBe('This is bold & <cool>');
+  });
+
+  it("skips comments without text", async () => {
+    const noText = {
+      objectID: "111",
+      comment_text: null,
+      author: "user4",
+      story_title: "Test",
+      created_at: "2025-01-01T00:00:00Z",
+    };
+    const withText = {
+      objectID: "222",
+      comment_text: "Actual comment",
+      author: "user5",
+      story_title: "Test",
+      created_at: "2025-01-01T00:00:00Z",
+    };
+    mockHNResponse([], [noText, withText]);
+
+    const result = await fetchHackerNews("TestCompany");
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0].id).toBe("222");
+  });
+
+  it("sorts stories by recency (newest first)", async () => {
+    const older = {
+      objectID: "1",
+      title: "Old",
+      url: null,
+      author: "a",
+      points: 10,
+      num_comments: 1,
+      created_at: "2025-01-01T00:00:00Z",
+    };
+    const newer = {
+      objectID: "2",
+      title: "New",
+      url: null,
+      author: "b",
+      points: 5,
+      num_comments: 0,
+      created_at: "2025-06-01T00:00:00Z",
+    };
+    mockHNResponse([older, newer]);
+
+    const result = await fetchHackerNews("TestCompany");
+    expect(result.stories[0].id).toBe("2");
+    expect(result.stories[1].id).toBe("1");
+  });
+
+  it("throws on API error", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503 });
+    await expect(fetchHackerNews("TestCompany")).rejects.toThrow("HN API error");
+  });
+
+  it("handles null points and num_comments gracefully", async () => {
+    const story = {
+      objectID: "999",
+      title: "No stats",
+      url: null,
+      author: "anon",
+      points: null,
+      num_comments: null,
+      created_at: "2025-03-01T00:00:00Z",
+    };
+    mockHNResponse([story]);
+
+    const result = await fetchHackerNews("TestCompany");
+    expect(result.stories[0].points).toBe(0);
+    expect(result.stories[0].numComments).toBe(0);
+  });
+});

--- a/src/lib/sources/reddit.test.ts
+++ b/src/lib/sources/reddit.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchReddit } from "./reddit";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Speed up rate-limit delays in tests
+vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: () => void) => {
+  fn();
+  return 0 as unknown as ReturnType<typeof setTimeout>;
+});
+
+const recentTimestamp = Math.floor(Date.now() / 1000) - 1000; // ~17 min ago
+
+function makeRedditSearchResponse(posts: Record<string, unknown>[] = []) {
+  return {
+    data: {
+      children: posts.map((p) => ({
+        data: {
+          id: p.id ?? "post1",
+          title: p.title ?? "Test Post",
+          selftext: p.selftext ?? "",
+          author: p.author ?? "testuser",
+          score: p.score ?? 10,
+          num_comments: p.num_comments ?? 0,
+          permalink: p.permalink ?? "/r/test/comments/abc/test_post",
+          created_utc: p.created_utc ?? recentTimestamp,
+        },
+      })),
+    },
+  };
+}
+
+function makeRedditCommentsResponse(comments: Record<string, unknown>[] = []) {
+  return [
+    { data: { children: [] } }, // post data (ignored)
+    {
+      data: {
+        children: comments.map((c) => ({
+          data: {
+            id: c.id ?? "comment1",
+            body: c.body ?? "Test comment",
+            author: c.author ?? "commenter",
+            score: c.score ?? 5,
+            created_utc: c.created_utc ?? recentTimestamp,
+          },
+        })),
+      },
+    },
+  ];
+}
+
+describe("fetchReddit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns correct structure with empty results", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { children: [] } }),
+    });
+
+    const result = await fetchReddit("TestCompany");
+    expect(result.source).toBe("reddit");
+    expect(result.subreddits).toContain("artificial");
+    expect(result.posts).toEqual([]);
+    expect(result.comments).toEqual([]);
+  });
+
+  it("generates search variants", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { children: [] } }),
+    });
+
+    const result = await fetchReddit("RunwayML");
+    expect(result.queries).toContain("RunwayML");
+    expect(result.queries).toContain("Runway ML");
+  });
+
+  it("deduplicates posts across subreddits", async () => {
+    const post = {
+      id: "same_post",
+      title: "Duplicate Post",
+      num_comments: 0,
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeRedditSearchResponse([post])),
+    });
+
+    const result = await fetchReddit("TestCompany");
+    const postIds = result.posts.filter((p) => p.id === "same_post");
+    expect(postIds.length).toBe(1);
+  });
+
+  it("strips markdown from post selftext", async () => {
+    const post = {
+      id: "md1",
+      selftext: "Check [this link](https://example.com) for **details**",
+      num_comments: 0,
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeRedditSearchResponse([post])),
+    });
+
+    const result = await fetchReddit("TestCompany");
+    const found = result.posts.find((p) => p.id === "md1");
+    expect(found?.selftext).toBe("Check this link for details");
+  });
+
+  it("fetches comments only for high-engagement posts (>3 comments)", async () => {
+    const lowEngagement = { id: "low", num_comments: 2 };
+    const highEngagement = { id: "high", num_comments: 10, permalink: "/r/test/comments/high/post" };
+
+    let callCount = 0;
+    mockFetch.mockImplementation((url: string) => {
+      callCount++;
+      if (url.includes("/comments/high/")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              makeRedditCommentsResponse([{ id: "c1", body: "Great discussion" }])
+            ),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(makeRedditSearchResponse([lowEngagement, highEngagement])),
+      });
+    });
+
+    const result = await fetchReddit("TestCompany");
+    // Should have comments from high-engagement post
+    expect(result.comments.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("filters out AutoModerator comments", async () => {
+    const post = { id: "p1", num_comments: 5, permalink: "/r/test/comments/p1/post" };
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/comments/")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              makeRedditCommentsResponse([
+                { id: "auto", body: "Post removed", author: "AutoModerator" },
+                { id: "real", body: "Real comment", author: "humanuser" },
+              ])
+            ),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(makeRedditSearchResponse([post])),
+      });
+    });
+
+    const result = await fetchReddit("TestCompany");
+    const autoComments = result.comments.filter((c) => c.author === "AutoModerator");
+    expect(autoComments).toHaveLength(0);
+  });
+
+  it("sorts posts by score (highest first)", async () => {
+    const posts = [
+      { id: "low", score: 5, num_comments: 0 },
+      { id: "high", score: 100, num_comments: 0 },
+      { id: "mid", score: 50, num_comments: 0 },
+    ];
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeRedditSearchResponse(posts)),
+    });
+
+    const result = await fetchReddit("TestCompany");
+    // After dedup across subreddits, check ordering of unique posts
+    const uniquePosts = result.posts.filter((p) =>
+      ["low", "high", "mid"].includes(p.id)
+    );
+    if (uniquePosts.length >= 2) {
+      for (let i = 1; i < uniquePosts.length; i++) {
+        expect(uniquePosts[i - 1].score).toBeGreaterThanOrEqual(uniquePosts[i].score);
+      }
+    }
+  });
+
+  it("skips posts older than daysBack cutoff", async () => {
+    const oldPost = {
+      id: "old",
+      created_utc: Math.floor(Date.now() / 1000) - 200 * 86400, // 200 days ago
+      num_comments: 0,
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeRedditSearchResponse([oldPost])),
+    });
+
+    const result = await fetchReddit("TestCompany", 90);
+    const found = result.posts.find((p) => p.id === "old");
+    expect(found).toBeUndefined();
+  });
+
+  it("handles API failures gracefully", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429 });
+
+    const result = await fetchReddit("TestCompany");
+    expect(result.posts).toEqual([]);
+    expect(result.comments).toEqual([]);
+  });
+});

--- a/src/lib/sources/youtube.test.ts
+++ b/src/lib/sources/youtube.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchYouTube } from "./youtube";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeSearchResponse(videos: { id: string; title?: string; channel?: string }[] = []) {
+  return {
+    items: videos.map((v) => ({
+      id: { videoId: v.id },
+      snippet: {
+        title: v.title ?? "Test Video",
+        channelTitle: v.channel ?? "TestChannel",
+        publishedAt: "2025-06-01T00:00:00Z",
+      },
+    })),
+  };
+}
+
+function makeStatsResponse(stats: { id: string; views?: string; comments?: string }[] = []) {
+  return {
+    items: stats.map((s) => ({
+      id: s.id,
+      statistics: {
+        viewCount: s.views ?? "1000",
+        commentCount: s.comments ?? "10",
+      },
+    })),
+  };
+}
+
+function makeCommentsResponse(comments: { id?: string; text?: string; author?: string }[] = []) {
+  return {
+    items: comments.map((c, i) => ({
+      id: c.id ?? `comment_${i}`,
+      snippet: {
+        topLevelComment: {
+          snippet: {
+            textDisplay: c.text ?? "Test comment",
+            authorDisplayName: c.author ?? "TestUser",
+            likeCount: 5,
+            publishedAt: "2025-06-01T00:00:00Z",
+          },
+        },
+      },
+    })),
+  };
+}
+
+describe("fetchYouTube", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns correct structure with empty results", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: [] }),
+    });
+
+    const result = await fetchYouTube("TestCompany", "fake-key");
+    expect(result.source).toBe("youtube");
+    expect(result.videos).toEqual([]);
+    expect(result.comments).toEqual([]);
+  });
+
+  it("generates search variants for camelCase names", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: [] }),
+    });
+
+    const result = await fetchYouTube("RunwayML", "fake-key");
+    expect(result.queries).toContain("RunwayML");
+    expect(result.queries).toContain("Runway ML");
+  });
+
+  it("fetches video stats after search", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeSearchResponse([{ id: "vid1" }])),
+        });
+      }
+      if (url.includes("/videos")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(makeStatsResponse([{ id: "vid1", views: "50000", comments: "0" }])),
+        });
+      }
+      // commentThreads - should not be called since commentCount is "0"
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ items: [] }),
+      });
+    });
+
+    const result = await fetchYouTube("TestCompany", "fake-key");
+    expect(result.videos).toHaveLength(1);
+    expect(result.videos[0].viewCount).toBe("50000");
+  });
+
+  it("deduplicates videos across query variants", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(makeSearchResponse([{ id: "dup_vid", title: "Same Video" }])),
+        });
+      }
+      if (url.includes("/videos")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(makeStatsResponse([{ id: "dup_vid", comments: "0" }])),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ items: [] }),
+      });
+    });
+
+    const result = await fetchYouTube("RunwayML", "fake-key");
+    const dupVids = result.videos.filter((v) => v.id === "dup_vid");
+    expect(dupVids).toHaveLength(1);
+  });
+
+  it("only fetches comments for top 5 videos by view count", async () => {
+    const videos = Array.from({ length: 8 }, (_, i) => ({
+      id: `v${i}`,
+      title: `Video ${i}`,
+    }));
+    const stats = Array.from({ length: 8 }, (_, i) => ({
+      id: `v${i}`,
+      views: String((8 - i) * 1000),
+      comments: "5",
+    }));
+
+    const commentFetchedFor: string[] = [];
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeSearchResponse(videos)),
+        });
+      }
+      if (url.includes("/videos")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeStatsResponse(stats)),
+        });
+      }
+      if (url.includes("/commentThreads")) {
+        const videoIdMatch = url.match(/videoId=([^&]+)/);
+        if (videoIdMatch) commentFetchedFor.push(videoIdMatch[1]);
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeCommentsResponse([{ text: "Nice" }])),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    await fetchYouTube("TestCompany", "fake-key");
+    expect(commentFetchedFor.length).toBeLessThanOrEqual(5);
+  });
+
+  it("skips comment fetching for videos with 0 comments", async () => {
+    let commentsFetched = false;
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeSearchResponse([{ id: "nocomments" }])),
+        });
+      }
+      if (url.includes("/videos")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(makeStatsResponse([{ id: "nocomments", comments: "0" }])),
+        });
+      }
+      if (url.includes("/commentThreads")) {
+        commentsFetched = true;
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    await fetchYouTube("TestCompany", "fake-key");
+    expect(commentsFetched).toBe(false);
+  });
+
+  it("handles search API failure gracefully", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve("Forbidden"),
+    });
+
+    const result = await fetchYouTube("TestCompany", "fake-key");
+    expect(result.videos).toEqual([]);
+    expect(result.comments).toEqual([]);
+  });
+
+  it("strips HTML from comment text", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeSearchResponse([{ id: "v1" }])),
+        });
+      }
+      if (url.includes("/videos")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(makeStatsResponse([{ id: "v1", comments: "1" }])),
+        });
+      }
+      if (url.includes("/commentThreads")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              makeCommentsResponse([{ text: "<b>Bold</b> and <i>italic</i> text" }])
+            ),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    const result = await fetchYouTube("TestCompany", "fake-key");
+    expect(result.comments[0].text).toBe("Bold and italic text");
+  });
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -121,6 +121,40 @@ create policy "Users can update their own findings"
   on public.findings for update
   using (user_id = current_setting('request.jwt.claims', true)::json->>'sub');
 
+-- Settings table (server-side storage for cron jobs and scheduled runs)
+create table public.settings (
+  id uuid default gen_random_uuid() primary key,
+  user_id text not null unique,
+  product_name text not null default '',
+  product_context text not null default '',
+  gemini_api_key text not null default '',
+  email text not null default '',
+  enabled_sources text[] not null default '{hackernews,reddit,youtube}',
+  schedule_enabled boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.settings enable row level security;
+
+create policy "Users can view their own settings"
+  on public.settings for select
+  using (user_id = current_setting('request.jwt.claims', true)::json->>'sub');
+
+create policy "Users can insert their own settings"
+  on public.settings for insert
+  with check (user_id = current_setting('request.jwt.claims', true)::json->>'sub');
+
+create policy "Users can update their own settings"
+  on public.settings for update
+  using (user_id = current_setting('request.jwt.claims', true)::json->>'sub');
+
+-- Add schedule_frequency to competitors (how often to auto-analyze)
+-- Defaults based on priority: Primary=weekly, Secondary=biweekly, Watch=monthly
+alter table public.competitors
+  add column schedule_frequency text not null default 'default'
+  check (schedule_frequency in ('daily', 'weekly', 'biweekly', 'monthly', 'never', 'default'));
+
 -- Indexes
 create index idx_competitors_user_id on public.competitors(user_id);
 create index idx_sources_competitor_id on public.sources(competitor_id);
@@ -130,3 +164,4 @@ create index idx_runs_user_id on public.runs(user_id);
 create index idx_findings_run_id on public.findings(run_id);
 create index idx_findings_competitor_id on public.findings(competitor_id);
 create index idx_findings_user_id on public.findings(user_id);
+create index idx_settings_user_id on public.settings(user_id);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/run",
+      "schedule": "0 7 * * *"
+    }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Enable the previously disabled Edit menu item on the competitors page.
Clicking Edit opens a dialog pre-filled with the competitor's current
name, website, priority, and notes, allowing inline updates via Supabase.

https://claude.ai/code/session_018T7uzX6k2VdSCBMftB3YVk